### PR TITLE
chore(docs): add action for slack notifications

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,21 @@
+name: Notify Slack on PR Merge
+
+on:
+    pull_request:
+        types: closed
+
+jobs:
+    if_merged:
+        if: github.event.pull_request.merged == true
+        runs-on: ubuntu-latest
+        steps:
+            - name: Send GitHub Action data to a Slack workflow
+              uses: slackapi/slack-github-action@v2.0.0
+              with:
+                payload: |
+                    {
+                        "author": "${{ github.event.pull_request.user.login }}",
+                        "pr_message": "${{ github.event.pull_request.body }}"
+                    }
+              env:
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL || 'No description provided.' }}


### PR DESCRIPTION
📘 **Docs Update:**

- 🧹 Chore

**Summary:**

This PR adds a GitHub action to send notifications to a Slack channel on PR merge.

This is to avoid cluttering our internal channel with opened/closed PR notifications (the GitHub Slack integration doesn't allow filtering PR notifications).

**Pages affected:**

(None)

**Other notes:**

The Webhook URL is for a private test channel for now.