### PR TITLE
fix(home): center text on home page

### DIFF
--- a/home.mdx
+++ b/home.mdx
@@ -7,7 +7,7 @@ import Home from '/snippets/home.mdx'
 
 <div className="flex flex-col items-center justify-center my-10">
   <h1 className="text-4xl text-gray-600 font-bold pb-2">Documentation</h1>
-  <p className="text-lg mb-4">Explore our guides and examples to learn how to use Botpress.</p>
+  <p className="text-lg mb-4 text-center">Explore our guides and examples to learn how to use Botpress.</p>
   <a href="guides/introduction">
     <button className="flex items-center gap-2 border border-gray-300 bg-blue-500 text-white rounded-lg shadow-md px-6 py-2 text-sm font-medium text-gray-800 hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
       Get Started


### PR DESCRIPTION
Fixes centering of text on the docs homepage (mobile).