### PR TITLE
docs(whatsapp): add additional proactive start method

### DIFF
--- a/integrations/integration-guides/whatsapp/whatsapp-start-proactively.mdx
+++ b/integrations/integration-guides/whatsapp/whatsapp-start-proactively.mdx
@@ -120,13 +120,24 @@ The output value of this action will be an object with the following structure:
 }
 ```
 
-## Create the conversation using the Botpress Client
+## Create the conversation from code
 
 <Note>
   This section is for advanced users who build their bot from code instead of in the Studio.
 </Note>
 
-If you're building a bot-as-code, you can use the Botpress Client instance provided to your bot's handlers to call this action programmatically. For example:
+If you're building a bot-as-code, you can call `actions.whatsapp.startConversation` to start a conversation:
+
+```ts
+actions.whatsapp.startConversation({
+  userPhone: '+1 123 456 7890',
+  templateName: 'test_message',
+  templateLanguage: 'en',
+  templateVariablesJson: JSON.stringify(['First value', 'Second value'])
+})
+```
+
+You can also use the Botpress Client instance provided to your bot's handlers:
 
 ```ts
 const result = await client.callAction({
@@ -134,8 +145,8 @@ const result = await client.callAction({
   input: {
     userPhone: '+1 123 456 7890',
     templateName: 'test_message',
-    templateLanguage: 'en_US',
-    templateVariablesJson: JSON.stringify(['John', '12345']),
+    templateLanguage: 'en',
+    templateVariablesJson: JSON.stringify(['First value', 'Second value']),
   },
 })
 

--- a/integrations/integration-guides/whatsapp/whatsapp-start-proactively.mdx
+++ b/integrations/integration-guides/whatsapp/whatsapp-start-proactively.mdx
@@ -122,11 +122,7 @@ The output value of this action will be an object with the following structure:
 
 ## Create the conversation from code
 
-<Note>
-  This section is for advanced users who build their bot from code instead of in the Studio.
-</Note>
-
-If you're building a bot-as-code, you can call `actions.whatsapp.startConversation` to start a conversation:
+You can also call `actions.whatsapp.startConversation` in an [Execute Code](/guides/studio/cards/execute) Card to start a conversation:
 
 ```ts
 actions.whatsapp.startConversation({
@@ -135,20 +131,4 @@ actions.whatsapp.startConversation({
   templateLanguage: 'en',
   templateVariablesJson: JSON.stringify(['First value', 'Second value'])
 })
-```
-
-You can also use the Botpress Client instance provided to your bot's handlers:
-
-```ts
-const result = await client.callAction({
-  type: 'whatsapp:startConversation',
-  input: {
-    userPhone: '+1 123 456 7890',
-    templateName: 'test_message',
-    templateLanguage: 'en',
-    templateVariablesJson: JSON.stringify(['First value', 'Second value']),
-  },
-})
-
-console.log('Botpress conversation ID: ' + result.conversationId)
 ```


### PR DESCRIPTION
Adds a code example for `actions.whatsapp.startConversation` to proactively start a WhatsApp conversation. This is helpful because IntelliSense will suggest the expected arguments.

Thanks @bassamtantawi-botpress for the suggestion