### PR TITLE
docs(LLMs): add page for using your own LLM

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -310,7 +310,8 @@
               "for-developers/sdk/integration/getting-started",
               "for-developers/sdk/integration/messaging",
               "for-developers/sdk/integration/concepts",
-              "for-developers/sdk/integration/publish-your-integration-on-botpress-hub"
+              "for-developers/sdk/integration/publish-your-integration-on-botpress-hub",
+              "for-developers/sdk/integration/use-your-own-llm"
             ]
           },
           {

--- a/for-developers/sdk/integration/use-your-own-llm.mdx
+++ b/for-developers/sdk/integration/use-your-own-llm.mdx
@@ -1,0 +1,19 @@
+---
+title: Use your own LLM
+---
+
+<Note>
+    Using your own LLM is available on [Enterprise plans](https://botpress.com/pricing). To get started with your own LLM, [contact our sales team](https://botpress.com/contact-us?ref=navbar).
+</Note>
+
+You can use the Botpress SDK to **integrate your own LLM**, giving you full control over the intelligence powering your AI agents.
+
+Bringing your own LLM can unlock greater flexibility and performance for your bot. You can:
+
+- Fine-tune your model for your industry
+- Align the model's tone and behaviour with your brand
+- Scale cost-effectively and extend your existing AI infrastructure
+
+<Tip>
+    If you're an LLM provider and are interested in monetizing your own LLM by making it available for use on Botpress, [contact us.](https://botpress.com/contact-us)
+</Tip>


### PR DESCRIPTION
Adds a page for using your own LLM. The page contains no actual instructions — just a summary of the feature and a reference to contact sales to get started.