### PR TITLE
fix: typo

### DIFF
--- a/integrations/integration-guides/vonage.mdx
+++ b/integrations/integration-guides/vonage.mdx
@@ -8,9 +8,9 @@ import { Img } from '/snippets/image.mdx'
 
 # Prerequisites
 
-* A [Vonage Account](https://dashboard.nexmo.com/sign-up)
-* A [Vonage Application](https://dashboard.nexmo.com/applications/new)
-* A [Botpress Cloud account](https://sso.botpress.cloud) and a [Botpress Bot](/guides/quick-start)
+- A [Vonage Account](https://dashboard.nexmo.com/sign-up)
+- A [Vonage Application](https://dashboard.nexmo.com/applications/new)
+- A [Botpress Cloud account](https://sso.botpress.cloud) and a [Botpress Bot](/guides/quick-start)
 
 # Setting up the Vonage integration in Botpress
 
@@ -34,7 +34,7 @@ Channel configuration is complete, you can now click **Save**
 
 ## Sandbox
 
-You can use the Vonage sandbox to test you channel with WhatsApp
+You can use the Vonage sandbox to test your channel with WhatsApp
 
 1. Check the **Use Testing API** box in your channel configuration
 2. Go to your [Sandbox Settings](https://dashboard.nexmo.com/messages/sandbox)


### PR DESCRIPTION
Fixes a typo.

@adkah I wonder if there's a vale rule we can add to check for typos like this:

> You can use the Vonage sandbox to test you channel with WhatsApp