### PR TITLE
fix(reference/home):add dark mode images

### DIFF
--- a/.vscode/mdx.code-snippets
+++ b/.vscode/mdx.code-snippets
@@ -1,27 +1,25 @@
 {
-	"Image": {
+	"Image with frame and light/dark support": {
 		"scope": "mdx",
-		"prefix": ["image", "Image"],
-		"body": [ "<Image",
-	"\talt=\"${1:alt}\"",
-	"\tsrc=\"${2:src}\"",
-	"\tsrcDark=\"${3:srcDark}\"",
-	"/>"]
+		"prefix": [
+			"image",
+			"Image",
+			"imgframe"
+		],
+		"body": [
+			"<Frame>",
+			"  <img",
+			"    alt=\"${TM_SELECTED_TEXT:alt}\"",
+			"    className=\"block dark:hidden\"",
+			"    src=\"${TM_FILEPATH/(.*docs)(.*)\\/[^\\/]+$/${2}/}/${1:image}.png\"",
+			"  />",
+			"  <img",
+			"    alt=\"${TM_SELECTED_TEXT:alt}\"",
+			"    className=\"hidden dark:block\"",
+			"    src=\"${TM_FILEPATH/(.*docs)(.*)\\/[^\\/]+$/${2}/}/${2:image}-dark.png\"",
+			"  />",
+			"</Frame>"
+		],
+		"description": "Inserts a Frame-wrapped image with support for light and dark mode"
 	}
-	// Place your docs workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
-	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
-	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
-	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
-	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
-	// Placeholders with the same ids are connected.
-	// Example:
-	// "Print to console": {
-	// 	"scope": "javascript,typescript",
-	// 	"prefix": "log",
-	// 	"body": [
-	// 		"console.log('$1');",
-	// 		"$2"
-	// 	],
-	// 	"description": "Log output to console"
-	// }
 }

--- a/guides/studio/interface/home.mdx
+++ b/guides/studio/interface/home.mdx
@@ -5,8 +5,6 @@ description: >-
 icon: house
 ---
 
-import { Image } from "/snippets/image.mdx"
-
 The <Icon icon="house"/> **Home** page is Botpress Studio's main menu. It displays general information about your bot and allows you to configure some global settings.
 
 Most of the options on the **Home** page are shortcuts to configure your main Workflow's [Autonomous Node](/guides/studio/interface/nodes/autonomous-node). If you don't use an Autonomous Node, you can still configure your bot's [communication channels](#communication-channels) or view a [detailed analysis of your bot's conversations](#conversation-analysis).
@@ -19,26 +17,32 @@ Most of the options on the **Home** page are shortcuts to configure your main Wo
 
 You can define a global prompt for your bot in the **Instructions** field. This prompt influences how the bot interprets and responds to user input by giving it a specific context or role to operate within:
 
-{/* <Image
-  alt="Instructions"
-  src="/home-instructions.png"
-  srcDark="/guides/studio/interface/home-instructions-dark.png"
-/> */}
-
 <Frame>
-![Instructions](/guides/studio/interface/home-instructions.png)
+  <img
+    alt="Instructions"
+    className="block dark:hidden"
+    src="/guides/studio/interface/home-instructions.png"
+  />
+  <img
+    alt="Instructions"
+    className="hidden dark:block"
+    src="/guides/studio/interface/home-instructions-dark.png"
+  />
 </Frame>
 
 The **Instructions** field directly maps to the **Instructions** for your main Workflow's Autonomous Node. When you update one, the other will also update:
 
-{/* <Image
-  alt="Instructions for Autonomous Node"
-  src="/guides/studio/interface/node-instructions.png"
-  srcDark="/guides/studio/interface/node-instructions-dark.png"
-/> */}
-
 <Frame>
-![Instructions for Autonomous Node](/guides/studio/interface/node-instructions.png)
+  <img
+    alt="Instructions for Autonomous Node"
+    className="block dark:hidden"
+    src="/guides/studio/interface/node-instructions.png"
+  />
+  <img
+    alt="Instructions for Autonomous Node"
+    className="hidden dark:block"
+    src="/guides/studio/interface/node-instructions-dark.png"
+  />
 </Frame>
 
 ## Knowledge Bases
@@ -49,14 +53,17 @@ The **Instructions** field directly maps to the **Instructions** for your main W
 
 You can add [Knowledge Bases](/guides/studio/interface/knowledge-base/) to give your bot sources it can reference when answering questions:
 
-{/* <Image
-  alt="Knowledge Bases"
-  src="/guides/studio/interface/knowledge-base.png"
-  srcDark="/guides/studio/interface/knowledge-base-dark.png"
-/> */}
-
 <Frame>
-![Knowledge Bases](/guides/studio/interface/knowledge-base.png)
+  <img
+    alt="Knowledge Bases"
+    className="block dark:hidden"
+    src="/guides/studio/interface/knowledge-base.png"
+  />
+  <img
+    alt="Knowledge Bases"
+    className="hidden dark:block"
+    src="/guides/studio/interface/knowledge-base-dark.png"
+  />
 </Frame>
 
 These sources can include documents, websites, tables, and other forms of structured (or unstructured) data. When you add Knowledge Bases, this section will display a summary of them.
@@ -69,26 +76,32 @@ These sources can include documents, websites, tables, and other forms of struct
 
 You can use the **Tools** section to quickly add resources and actions your bot can use:
 
-{/* <Image
-  alt="Tools"
-  src="/guides/studio/interface/tools.png"
-  srcDark="/guides/studio/interface/tools-dark.png"
-/> */}
-
 <Frame>
-![Tools](/guides/studio/interface/tools.png)
+  <img
+    alt="Tools"
+    className="block dark:hidden"
+    src="/guides/studio/interface/tools.png"
+  />
+  <img
+    alt="Tools"
+    className="hidden dark:block"
+    src="/guides/studio/interface/tools-dark.png"
+  />
 </Frame>
 
 The **Tools** section directly maps to the Cards in your main Workflow's Autonomous Node. When you update one, the other will also update:
 
-{/* <Image
-  alt="Autonomous Node Cards"
-  src="/guides/studio/interface/node-cards.png"
-  srcDark="/guides/studio/interface/node-cards-dark.png"
-/> */}
-
 <Frame>
-![Autonomous Node Cards](/guides/studio/interface/node-cards.png)
+  <img
+    alt="Autonomous Node Cards"
+    className="block dark:hidden"
+    src="/guides/studio/interface/node-cards.png"
+  />
+  <img
+    alt="Autonomous Node Cards"
+    className="hidden dark:block"
+    src="/guides/studio/interface/node-cards-dark.png"
+  />
 </Frame>
 
 ## Communication Channels
@@ -99,14 +112,17 @@ The **Tools** section directly maps to the Cards in your main Workflow's Autonom
 
 You can deploy your bot in different channels  the **Communication Channels** section:
 
-{/* <Image
-  alt="Communication Channels"
-  src="/guides/studio/interface/comm-channels.png"
-  srcDark="/guides/studio/interface/comm-channels-dark.png"
-/> */}
-
 <Frame>
-![Communication Channels](/guides/studio/interface/comm-channels.png)
+  <img
+    alt="Communication Channels"
+    className="block dark:hidden"
+    src="/guides/studio/interface/comm-channels.png"
+  />
+  <img
+    alt="Communication Channels"
+    className="hidden dark:block"
+    src="/guides/studio/interface/comm-channels-dark.png"
+  />
 </Frame>
 
 ## Conversation analysis
@@ -121,12 +137,15 @@ You can view a summary of your bot's conversations in the **Conversation Analysi
 
 You can provide feedback on your bot's responses in the [Emulator](/guides/studio/interface/emulator). Then, you can view a summary of your feedback in the **Learning Experiences** section:
 
-{/* <Image
-  alt="Learning experiences"
-  src="/guides/studio/interface/learning-experiences.png"
-  srcDark="/guides/studio/interface/learning-experiences-dark.png"
-/> */}
-
 <Frame>
-![Learning experiences](/guides/studio/interface/learning-experiences.png)
+  <img
+    alt="Learning experiences"
+    className="block dark:hidden"
+    src="/guides/studio/interface/learning-experiences.png"
+  />
+  <img
+    alt="Learning experiences"
+    className="hidden dark:block"
+    src="/guides/studio/interface/learning-experiences-dark.png"
+  />
 </Frame>


### PR DESCRIPTION
Adds dark mode images for the updated home page, since they weren't working within the image snippet from #103.