### PR TITLE
fix(sdk/interface):  broken snippet import

### DIFF
--- a/for-developers/sdk/interface/how-tos/implementing-hitl.mdx
+++ b/for-developers/sdk/interface/how-tos/implementing-hitl.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Implement HITL
 
 import { HitlIcon } from '/snippets/icons/plugins/hitl.mdx'
 import { CurrentInterfaceVersion } from '/snippets/interface-version.mdx'
-import { DefinitionList, Definition, DefinitionReference as Term } from '/snippets/definition-list.mdx'
+import { DefinitionList, Definition, DefinitionReference } from '/snippets/definition-list.mdx'
 
 <p>
   <HitlIcon width={64} style={{float: 'left', marginRight: 5}} role="presentation" />
@@ -45,16 +45,16 @@ Throughout this document, we will use the following terms:
 
 ## External service requirements
 
-The <Term id="external-service"/> providing HITL functionality **must** support the following:
+The <DefinitionReference id="external-service"/> providing HITL functionality **must** support the following:
 
-- An API that allows creating <Term id="external-user" plural/>.
-- An API that allows creating <Term id="hitl-session" plural/>.
-- An API that allows adding messages to <Term id="hitl-session" plural/>.
-- An API that allows closing <Term id="hitl-session" plural/>.
-- Webhooks that can notify your <Term id="integration"/> of the following events:
-  - <Term id="hitl-session" capitalize/> closure.
-  - <Term id="human-agent" capitalize/> assignment.
-  - <Term id="human-agent" capitalize/> reply.
+- An API that allows creating <DefinitionReference id="external-user" plural/>.
+- An API that allows creating <DefinitionReference id="hitl-session" plural/>.
+- An API that allows adding messages to <DefinitionReference id="hitl-session" plural/>.
+- An API that allows closing <DefinitionReference id="hitl-session" plural/>.
+- Webhooks that can notify your <DefinitionReference id="integration"/> of the following events:
+  - <DefinitionReference id="hitl-session" capitalize/> closure.
+  - <DefinitionReference id="human-agent" capitalize/> assignment.
+  - <DefinitionReference id="human-agent" capitalize/> reply.
 
 ## Updating your `package.json` file
 
@@ -66,14 +66,14 @@ You will need this version number for the next steps.
 
 ### Adding the interface as a dependency
 
-Once you have the <Term id="hitl-interface"/> version, you can add it as a dependency to your <Term id="integration"/>:
+Once you have the <DefinitionReference id="hitl-interface"/> version, you can add it as a dependency to your <DefinitionReference id="integration"/>:
 
 <Steps>
   <Step title="Open the package.json file">
-    Open your <Term id="integration"/>'s `package.json` file.
+    Open your <DefinitionReference id="integration"/>'s `package.json` file.
   </Step>
   <Step title="Add the bpDependencies section">
-    If there is no `bpDependencies` section in your <Term id="integration"/>'s `package.json` file, create one:
+    If there is no `bpDependencies` section in your <DefinitionReference id="integration"/>'s `package.json` file, create one:
     ```json package.json {2}
     {
       "bpDependencies": {}
@@ -81,7 +81,7 @@ Once you have the <Term id="hitl-interface"/> version, you can add it as a depen
     ```
   </Step>
   <Step title="Add the interface as a dependency">
-    In the `bpDependencies` section, add the <Term id="hitl-interface"/> as a dependency. For example, for version `0.4.0`, you would add the following:
+    In the `bpDependencies` section, add the <DefinitionReference id="hitl-interface"/> as a dependency. For example, for version `0.4.0`, you would add the following:
     ```json package.json {3}
     {
       "bpDependencies": {
@@ -98,19 +98,19 @@ Once you have the <Term id="hitl-interface"/> version, you can add it as a depen
     Save the `package.json` file.
   </Step>
   <Step title="Install the interface">
-  Now that you have added the <Term id="hitl-interface"/> as a dependency, you can run the [`bp add`](/for-developers/cli/commands/add) command to install it. This command will:
+  Now that you have added the <DefinitionReference id="hitl-interface"/> as a dependency, you can run the [`bp add`](/for-developers/cli/commands/add) command to install it. This command will:
   - Download the interface from Botpress.
-  - Install it in a directory named `bp_modules` in your <Term id="integration"/>'s root directory.
+  - Install it in a directory named `bp_modules` in your <DefinitionReference id="integration"/>'s root directory.
   </Step>
 </Steps>
 
 ### Adding a helper build script
 
-To keep your <Term id="integration"/> up to date, we recommend adding a helper build script to your `package.json` file:
+To keep your <DefinitionReference id="integration"/> up to date, we recommend adding a helper build script to your `package.json` file:
 
 <Steps>
   <Step title="Open the package.json file">
-    Open your <Term id="integration"/>'s `package.json` file.
+    Open your <DefinitionReference id="integration"/>'s `package.json` file.
   </Step>
   <Step title="Add the build script">
     In the `scripts` section, add the following script:
@@ -130,20 +130,20 @@ To keep your <Term id="integration"/> up to date, we recommend adding a helper b
   </Step>
 </Steps>
 
-Now, whenever you run `npm run build`, it will automatically install the <Term id="hitl-interface" /> and build your <Term id="integration" />.
+Now, whenever you run `npm run build`, it will automatically install the <DefinitionReference id="hitl-interface" /> and build your <DefinitionReference id="integration" />.
 
 ## Editing your integration definition file
 
 ### Adding the interface to your integration definition file
 
-Now that the <Term id="hitl-interface"/> is installed, you must add it your integration definition file in order to implement it.
+Now that the <DefinitionReference id="hitl-interface"/> is installed, you must add it your integration definition file in order to implement it.
 
 <Steps>
   <Step title="Open the integration.definition.ts file">
-    Open your <Term id="integration"/>'s `integration.definition.ts` file.
+    Open your <DefinitionReference id="integration"/>'s `integration.definition.ts` file.
   </Step>
   <Step title="Import the interface">
-    At the top of the file, import the <Term id="hitl-interface"/>:
+    At the top of the file, import the <DefinitionReference id="hitl-interface"/>:
     ```typescript integration.definition.ts
     import hitl from './bp_modules/hitl'
     ```
@@ -170,16 +170,16 @@ The `.extend()` function takes two arguments:
 - The second argument is a configuration object. Using this object, you can override interface defaults with custom names, titles, and descriptions.
 
 <Tip>
-Whilst renaming actions, events and channels is optional, it is highly recommended to rename these to match the terminology of the <Term id="external-service"/>. This will help you avoid confusion and make your <Term id="integration"/> easier to understand.
+Whilst renaming actions, events and channels is optional, it is highly recommended to rename these to match the terminology of the <DefinitionReference id="external-service"/>. This will help you avoid confusion and make your <DefinitionReference id="integration"/> easier to understand.
 </Tip>
 
 #### Renaming actions
 
-The `hitl` interface defines three actions that are used to interact with the <Term id="external-service"/>:
+The `hitl` interface defines three actions that are used to interact with the <DefinitionReference id="external-service"/>:
 
-- `createUser` - Used by the <Term id="hitl-plugin"/> to request the creation of a user in the <Term id="external-service"/> and on Botpress.
-- `startHitl` - Used by the <Term id="hitl-plugin"/> to request the creation of a <Term id="hitl-session"/> in the <Term id="external-service"/>.
-- `stopHitl` - Used by the <Term id="hitl-plugin"/> to request the closure of a <Term id="hitl-session"/> in the <Term id="external-service"/>.
+- `createUser` - Used by the <DefinitionReference id="hitl-plugin"/> to request the creation of a user in the <DefinitionReference id="external-service"/> and on Botpress.
+- `startHitl` - Used by the <DefinitionReference id="hitl-plugin"/> to request the creation of a <DefinitionReference id="hitl-session"/> in the <DefinitionReference id="external-service"/>.
+- `stopHitl` - Used by the <DefinitionReference id="hitl-plugin"/> to request the closure of a <DefinitionReference id="hitl-session"/> in the <DefinitionReference id="external-service"/>.
 
 If you want to rename these actions, you can do so in the configuration object. For example, if you want to rename `createUser` to `hitlCreateUser`, you can do it like this:
 
@@ -194,15 +194,15 @@ If you want to rename these actions, you can do so in the configuration object. 
 ```
 
 <Tip>
-For example, if you're using a _help desk_ system like Zendesk, JIRA Service Desk, or Freshdesk for HITL functionality, you might rename `startHitl` to `createTicket` and `stopHitl` to `closeTicket`. These systems use tickets to represent help requests, so renaming actions to match their terminology makes your <Term id="integration"/> clearer and easier to understand.
+For example, if you're using a _help desk_ system like Zendesk, JIRA Service Desk, or Freshdesk for HITL functionality, you might rename `startHitl` to `createTicket` and `stopHitl` to `closeTicket`. These systems use tickets to represent help requests, so renaming actions to match their terminology makes your <DefinitionReference id="integration"/> clearer and easier to understand.
 </Tip>
 
 #### Renaming events
 
 The `hitl` interface defines these events to notify the plugin of changes in the external service:
 
-- `hitlAssigned` - Emitted by your <Term id="integration"/> to notify the <Term id="hitl-plugin"/> that a <Term id="human-agent"/> has been assigned to a <Term id="hitl-session"/>.
-- `hitlStopped` - Emitted by your <Term id="integration"/> to notify the <Term id="hitl-plugin"/> that a <Term id="hitl-session"/> has been closed.
+- `hitlAssigned` - Emitted by your <DefinitionReference id="integration"/> to notify the <DefinitionReference id="hitl-plugin"/> that a <DefinitionReference id="human-agent"/> has been assigned to a <DefinitionReference id="hitl-session"/>.
+- `hitlStopped` - Emitted by your <DefinitionReference id="integration"/> to notify the <DefinitionReference id="hitl-plugin"/> that a <DefinitionReference id="hitl-session"/> has been closed.
 
 If you want to rename these events, you can do so in the configuration object. For example, if you want to rename `hitlAssigned` to `agentAssigned`, you can do it like this:
 
@@ -220,7 +220,7 @@ If you want to rename these events, you can do so in the configuration object. F
 
 The `hitl` interface defines these channels:
 
-- `hitl` - Used by the <Term id="hitl-plugin"/> to send and receive messages from the <Term id="external-service"/>. This represents the communication channel for the <Term id="hitl-session"/>, like a support ticket on Zendesk or a direct message thread on Slack.
+- `hitl` - Used by the <DefinitionReference id="hitl-plugin"/> to send and receive messages from the <DefinitionReference id="external-service"/>. This represents the communication channel for the <DefinitionReference id="hitl-session"/>, like a support ticket on Zendesk or a direct message thread on Slack.
 
 If you want to rename this channel, you can do so in the configuration object. For example, if you want to rename `hitl` to `supportTicket`, you can do it like this:
 
@@ -240,7 +240,7 @@ If you want to rename this channel, you can do so in the configuration object. F
 
 #### Implementing `createUser`
 
-The `createUser` action is used by the <Term id="hitl-plugin"/> to request the creation of an <Term id="external-user"/> (a _requester_) in the <Term id="external-service"/>.
+The `createUser` action is used by the <DefinitionReference id="hitl-plugin"/> to request the creation of an <DefinitionReference id="external-user"/> (a _requester_) in the <DefinitionReference id="external-service"/>.
 
 <Note>
 If you opted to rename the action to something else than `createUser` in the "Configuring the interface" section, please use the new name instead of `createUser`.
@@ -256,13 +256,13 @@ This action should implement the following logic:
     Create a Botpress user using the Botpress client by calling the `client.createUser()` method.
   </Step>
   <Step title="Create an external user">
-    Create an <Term id="external-user"/> on the <Term id="external-service"/> using the <Term id="external-service"/>'s API or SDK.
+    Create an <DefinitionReference id="external-user"/> on the <DefinitionReference id="external-service"/> using the <DefinitionReference id="external-service"/>'s API or SDK.
   </Step>
   <Step title="Map the external user to the Botpress user">
-    Update the <Term id="external-user"/> on the <Term id="external-service"/> to map it to the Botpress user. Please refer to the <Term id="external-service"/>'s documentation to know how to set extra metadata for the <Term id="external-user"/>. The <Term id="integration"/> must be able at any time to query the <Term id="external-service"/> in order to retrieve the Botpress user ID from the <Term id="external-user"/>.
+    Update the <DefinitionReference id="external-user"/> on the <DefinitionReference id="external-service"/> to map it to the Botpress user. Please refer to the <DefinitionReference id="external-service"/>'s documentation to know how to set extra metadata for the <DefinitionReference id="external-user"/>. The <DefinitionReference id="integration"/> must be able at any time to query the <DefinitionReference id="external-service"/> in order to retrieve the Botpress user ID from the <DefinitionReference id="external-user"/>.
   </Step>
   <Step title="Map the Botpress user to the external user">
-    Update the Botpress user to map it to the <Term id="external-user"/>. This is typically done by setting a tag on the Botpress user with the <Term id="external-user"/>'s ID.
+    Update the Botpress user to map it to the <DefinitionReference id="external-user"/>. This is typically done by setting a tag on the Botpress user with the <DefinitionReference id="external-user"/>'s ID.
   </Step>
   <Step title="Yield control back to the plugin">
     Yield control back to the plugin by returning an object containing the Botpress user's ID.
@@ -316,7 +316,7 @@ export default new bp.Integration({
 
 #### Implementing `startHitl`
 
-The `startHitl` action is used by the <Term id="hitl-plugin"/> to request the creation of a <Term id="hitl-session"/> (typically a _ticket_) in the <Term id="external-service"/>.
+The `startHitl` action is used by the <DefinitionReference id="hitl-plugin"/> to request the creation of a <DefinitionReference id="hitl-session"/> (typically a _ticket_) in the <DefinitionReference id="external-service"/>.
 
 <Note>
 If you opted to rename the action to something else than `startHitl` in the "Configuring the interface" section, please use the new name instead of `startHitl`.
@@ -332,19 +332,19 @@ This action should implement the following logic:
     Fetch the Botpress user with ID `input.userId` that was passed in the input parameters.
   </Step>
   <Step title="Retrieve the external user's ID">
-    From the Botpress user's tags, retrieve the <Term id="external-user"/>'s ID.
+    From the Botpress user's tags, retrieve the <DefinitionReference id="external-user"/>'s ID.
   </Step>
   <Step title="Create a Botpress conversation">
     Create a Botpress conversation using the Botpress client by calling the `client.getOrCreateConversation()` method.
   </Step>
   <Step title="Create the HITL session">
-    On the <Term id="external-service"/>, create the <Term id="hitl-session"/>. This is typically represented as a _ticket_ in the <Term id="external-service"/>.
+    On the <DefinitionReference id="external-service"/>, create the <DefinitionReference id="hitl-session"/>. This is typically represented as a _ticket_ in the <DefinitionReference id="external-service"/>.
   </Step>
   <Step title="Map the Botpress conversation to the HITL session">
-    Update the Botpress conversation to map it to the <Term id="hitl-session"/>. This is typically achieved by setting a `ticketId` tag on the Botpress conversation.
+    Update the Botpress conversation to map it to the <DefinitionReference id="hitl-session"/>. This is typically achieved by setting a `ticketId` tag on the Botpress conversation.
   </Step>
   <Step title="Map the HITL session to the Botpress conversation">
-    Update the <Term id="hitl-session"/> on the <Term id="external-service"/> to map it to the Botpress conversation. Please refer to the <Term id="external-service"/>'s documentation to know how to set extra metadata for the <Term id="hitl-session"/> (typically a _ticket_). The <Term id="integration"/> must be able at any time to query the <Term id="external-service"/> in order to retrieve the Botpress conversation ID from the <Term id="hitl-session"/>.
+    Update the <DefinitionReference id="hitl-session"/> on the <DefinitionReference id="external-service"/> to map it to the Botpress conversation. Please refer to the <DefinitionReference id="external-service"/>'s documentation to know how to set extra metadata for the <DefinitionReference id="hitl-session"/> (typically a _ticket_). The <DefinitionReference id="integration"/> must be able at any time to query the <DefinitionReference id="external-service"/> in order to retrieve the Botpress conversation ID from the <DefinitionReference id="hitl-session"/>.
   </Step>
   <Step title="Yield control back to the plugin">
     Yield control back to the plugin by returning an object containing the Botpress conversation's ID.
@@ -404,7 +404,7 @@ export default new bp.Integration({
 
 #### Relaying the conversation history
 
-The input parameters of the `startHitl` action contain a `messageHistory` parameter. This parameter contains the conversation history that should be relayed to the <Term id="external-service"/> to provide the <Term id="human-agent"/> with context about the conversation. This parameter is an array of every message that was sent in the conversation prior to the <Term id="hitl-session"/> being started.
+The input parameters of the `startHitl` action contain a `messageHistory` parameter. This parameter contains the conversation history that should be relayed to the <DefinitionReference id="external-service"/> to provide the <DefinitionReference id="human-agent"/> with context about the conversation. This parameter is an array of every message that was sent in the conversation prior to the <DefinitionReference id="hitl-session"/> being started.
 
 <Expandable title="TypeScript schema for the messageHistory parameter">
 ```typescript
@@ -619,7 +619,7 @@ interface MarkdownMessage {
 ```
 </Expandable>
 
-If you decide to relay the conversation history to the <Term id="external-service"/>, you can do so by iterating over the `messageHistory` array and sending each message to the <Term id="external-service"/> using its API or SDK. However, doing so might cause a significant number of notifications being sent to the <Term id="external-service"/>. To alleviate this, you can choose to send only the last few messages in the conversation history, or to concatenate the messages into a single message. For example you could combine messages like this:
+If you decide to relay the conversation history to the <DefinitionReference id="external-service"/>, you can do so by iterating over the `messageHistory` array and sending each message to the <DefinitionReference id="external-service"/> using its API or SDK. However, doing so might cause a significant number of notifications being sent to the <DefinitionReference id="external-service"/>. To alleviate this, you can choose to send only the last few messages in the conversation history, or to concatenate the messages into a single message. For example you could combine messages like this:
 
 ```markdown
 ## User1 said:
@@ -631,7 +631,7 @@ If you decide to relay the conversation history to the <Term id="external-servic
 
 #### Implementing `stopHitl`
 
-The `stopHitl` action is used by the <Term id="hitl-plugin"/> to request the closure of a <Term id="hitl-session"/> (typically a _ticket_) in the <Term id="external-service"/>.
+The `stopHitl` action is used by the <DefinitionReference id="hitl-plugin"/> to request the closure of a <DefinitionReference id="hitl-session"/> (typically a _ticket_) in the <DefinitionReference id="external-service"/>.
 
 <Note>
 If you opted to rename the action to something else than `stopHitl` in the "Configuring the interface" section, please use the new name instead of `stopHitl`.
@@ -647,10 +647,10 @@ This action should implement the following logic:
     Fetch the Botpress conversation with ID `input.conversationId` that was passed in the input parameters.
   </Step>
   <Step title="Retrieve the HITL session's ID">
-    From the Botpress conversation's tags, retrieve the <Term id="hitl-session"/>'s ID.
+    From the Botpress conversation's tags, retrieve the <DefinitionReference id="hitl-session"/>'s ID.
   </Step>
   <Step title="Close the HITL session">
-    On the <Term id="external-service"/>, close the <Term id="hitl-session"/>. This is typically involves _resolving_ or _closing_ a _ticket_ in the <Term id="external-service"/>.
+    On the <DefinitionReference id="external-service"/>, close the <DefinitionReference id="hitl-session"/>. This is typically involves _resolving_ or _closing_ a _ticket_ in the <DefinitionReference id="external-service"/>.
   </Step>
   <Step title="Yield control back to the plugin">
     Yield control back to the plugin by returning an empty object.
@@ -658,7 +658,7 @@ This action should implement the following logic:
 </Steps>
 
 <Note>
-  The input parameters contain an unused `reason` parameter. Please ignore it. This parameter will be removed in future versions of the <Term id="hitl-interface"/>.
+  The input parameters contain an unused `reason` parameter. Please ignore it. This parameter will be removed in future versions of the <DefinitionReference id="hitl-interface"/>.
 </Note>
 
 As reference, here's how this logic is implemented in the Zendesk integration:
@@ -694,7 +694,7 @@ export default new bp.Integration({
 
 ### Implementing the channel
 
-The `hitl` channel is used by the <Term id="hitl-plugin"/> relay <Term id="end-user"/> messages to the <Term id="hitl-session"/>, which is usually a _ticket_ or _thread_ in the <Term id="external-service"/>.
+The `hitl` channel is used by the <DefinitionReference id="hitl-plugin"/> relay <DefinitionReference id="end-user"/> messages to the <DefinitionReference id="hitl-session"/>, which is usually a _ticket_ or _thread_ in the <DefinitionReference id="external-service"/>.
 
 <Note>
 If you opted to rename the channel to something else than `hitl` in the "Configuring the interface" section, please use the new name instead of `hitl`.
@@ -704,14 +704,14 @@ This channel handler should implement the following logic:
 
 <Steps>
   <Step title="Retrieve the HITL session's ID">
-    From the Botpress conversation's tags, retrieve the <Term id="hitl-session"/>'s ID.
+    From the Botpress conversation's tags, retrieve the <DefinitionReference id="hitl-session"/>'s ID.
   </Step>
   <Step title="Retrieve the external user's ID">
-    - If the payload contains a `userId` parameter, the message has been sent by the <Term id="end-user"/>. Retrieve the <Term id="external-user"/>'s ID from the tags of the Botpress user `payload.userId`.
-    - If the payload does not contain a `userId` parameter, the message has been sent by the bot. Retrieve the <Term id="external-user"/>'s ID from the tags of the attached Botpress user.
+    - If the payload contains a `userId` parameter, the message has been sent by the <DefinitionReference id="end-user"/>. Retrieve the <DefinitionReference id="external-user"/>'s ID from the tags of the Botpress user `payload.userId`.
+    - If the payload does not contain a `userId` parameter, the message has been sent by the bot. Retrieve the <DefinitionReference id="external-user"/>'s ID from the tags of the attached Botpress user.
   </Step>
   <Step title="Send the message to the HITL session">
-    Using the <Term id="external-service"/>'s API or SDK, send the message to the <Term id="hitl-session"/>. This is typically a _comment_ in a _ticket_.
+    Using the <DefinitionReference id="external-service"/>'s API or SDK, send the message to the <DefinitionReference id="hitl-session"/>. This is typically a _comment_ in a _ticket_.
   </Step>
 </Steps>
 
@@ -746,22 +746,22 @@ export default new bp.Integration({
 
 ### Implementing the events
 
-You should set up webhooks so that the <Term id="integration"/> receives notifications about these events:
+You should set up webhooks so that the <DefinitionReference id="integration"/> receives notifications about these events:
 
-- A new message is added to the <Term id="hitl-session"/> (usually a _ticket_).
-- A <Term id="human-agent"/> has been assigned to the <Term id="hitl-session"/>.
-- The <Term id="hitl-session"/> was closed.
+- A new message is added to the <DefinitionReference id="hitl-session"/> (usually a _ticket_).
+- A <DefinitionReference id="human-agent"/> has been assigned to the <DefinitionReference id="hitl-session"/>.
+- The <DefinitionReference id="hitl-session"/> was closed.
 
 #### Incoming messages
 
-When notified by the <Term id="external-service"/> that a new message has been added to the <Term id="hitl-session"/>, you should relay the message to the Botpress conversation:
+When notified by the <DefinitionReference id="external-service"/> that a new message has been added to the <DefinitionReference id="hitl-session"/>, you should relay the message to the Botpress conversation:
 
 <Steps>
   <Step title="Retrieve the Botpress conversation's ID">
-    Retrieve the Botpress conversation's ID from the <Term id="hitl-session"/>'s metadata.
+    Retrieve the Botpress conversation's ID from the <DefinitionReference id="hitl-session"/>'s metadata.
   </Step>
   <Step title="Retrieve the external user's ID">
-    Retrieve the <Term id="external-user"/>'s ID from the <Term id="hitl-session"/>'s metadata.
+    Retrieve the <DefinitionReference id="external-user"/>'s ID from the <DefinitionReference id="hitl-session"/>'s metadata.
   </Step>
   <Step title="Add a message to the Botpress conversation">
     Using the Botpress client, add a message to the Botpress conversation by calling the `client.createMessage()` method.
@@ -770,14 +770,14 @@ When notified by the <Term id="external-service"/> that a new message has been a
 
 #### Implementing `hitlAssigned`
 
-When notified by the <Term id="external-service"/> that a <Term id="human-agent"/> has been assigned to the <Term id="hitl-session"/>, you should notify the <Term id="hitl-plugin"/> by emitting the `hitlAssigned` event:
+When notified by the <DefinitionReference id="external-service"/> that a <DefinitionReference id="human-agent"/> has been assigned to the <DefinitionReference id="hitl-session"/>, you should notify the <DefinitionReference id="hitl-plugin"/> by emitting the `hitlAssigned` event:
 
 <Steps>
   <Step title="Retrieve the Botpress conversation's ID">
-    Retrieve the Botpress conversation's ID from the <Term id="hitl-session"/>'s metadata.
+    Retrieve the Botpress conversation's ID from the <DefinitionReference id="hitl-session"/>'s metadata.
   </Step>
   <Step title="Retrieve the external user's ID">
-    Retrieve the <Term id="external-user"/>'s ID from the <Term id="hitl-session"/>'s metadata.
+    Retrieve the <DefinitionReference id="external-user"/>'s ID from the <DefinitionReference id="hitl-session"/>'s metadata.
   </Step>
   <Step title="Emit the hitlAssigned event">
     Using the Botpress client, emit the `hitlAssigned` event by calling the `client.createEvent()` method.
@@ -790,14 +790,14 @@ When notified by the <Term id="external-service"/> that a <Term id="human-agent"
 
 #### Implementing `hitlStopped`
 
-When notified by the <Term id="external-service"/> that the <Term id="hitl-session"/> was closed, you should notify the <Term id="hitl-plugin"/> by emitting the `hitlStopped` event:
+When notified by the <DefinitionReference id="external-service"/> that the <DefinitionReference id="hitl-session"/> was closed, you should notify the <DefinitionReference id="hitl-plugin"/> by emitting the `hitlStopped` event:
 
 <Steps>
   <Step title="Retrieve the Botpress conversation's ID">
-    Retrieve the Botpress conversation's ID from the <Term id="hitl-session"/>'s metadata.
+    Retrieve the Botpress conversation's ID from the <DefinitionReference id="hitl-session"/>'s metadata.
   </Step>
   <Step title="Retrieve the external user's ID">
-    Retrieve the <Term id="external-user"/>'s ID from the <Term id="hitl-session"/>'s metadata.
+    Retrieve the <DefinitionReference id="external-user"/>'s ID from the <DefinitionReference id="hitl-session"/>'s metadata.
   </Step>
   <Step title="Emit the hitlStopped event">
     Using the Botpress client, emit the `hitlStopped` event by calling the `client.createEvent()` method.


### PR DESCRIPTION
Fixes the broken HITL page in the SDK docs, which was caused by snippet import raising an error.