### PR TITLE
feat(ui): hide assistant and search bar  

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,3 @@
 #assistant-entry {
   display: none;
 }
-
-#search-bar-entry {
-  display: none;
-}

--- a/styles.css
+++ b/styles.css
@@ -1,19 +1,27 @@
 .transparent-accordion .bg-background-light {
-    background-color: transparent !important;
+  background-color: transparent !important;
 }
 
 /* Info callout background and border */
-.callout[data-callout-type="info"]{
-    background-color: light-dark(rgba(253, 244, 255, 0.5), rgba(217, 70, 239, 0.1));
-    border-color: light-dark(rgba(217, 70, 239, 0.2), rgba(168, 85, 247, 0.3));
+.callout[data-callout-type='info'] {
+  background-color: light-dark(rgba(253, 244, 255, 0.5), rgba(217, 70, 239, 0.1));
+  border-color: light-dark(rgba(217, 70, 239, 0.2), rgba(168, 85, 247, 0.3));
 }
 
 /* Info callout icon */
-.callout[data-callout-type="info"] [data-component-part="callout-icon"] svg{
-  color: light-dark(rgba(192, 38, 211), rgba(232, 121, 249, 0.8))
+.callout[data-callout-type='info'] [data-component-part='callout-icon'] svg {
+  color: light-dark(rgba(192, 38, 211), rgba(232, 121, 249, 0.8));
 }
 
 /* Info callout text */
-.callout[data-callout-type="info"] [data-component-part="callout-content"] {
-  color: light-dark(rgba(112, 26, 117), rgba(245, 208, 254))
+.callout[data-callout-type='info'] [data-component-part='callout-content'] {
+  color: light-dark(rgba(112, 26, 117), rgba(245, 208, 254));
+}
+
+#assistant-entry {
+  display: none;
+}
+
+#search-bar-entry {
+  display: none;
 }


### PR DESCRIPTION
Added CSS to hide assistant and search bar entry elements

This PR adds CSS rules to hide the assistant and search bar entry elements from the UI. Mintlify bill is more than doubling each month so I am disabling those features for now.
