### PR TITLE
fix(integrations/zendesk): add warning for multiple bots

### DIFF
--- a/integrations/integration-guides/zendesk.mdx
+++ b/integrations/integration-guides/zendesk.mdx
@@ -21,6 +21,9 @@ Your Zendesk agent can continue the conversation on any messaging channel suppor
   - A [published bot](/learn/get-started/quick-start)
   - A [Zendesk account](https://www.zendesk.com/lp/brand/?utm_source=google&utm_medium=Search-Paid&utm_network=g&utm_campaign=SE_AW_AM_CA_EN_N_Sup_Brand_TM_Alpha_D_H&matchtype=e&utm_term=zendesk&utm_content=598844228779&theme=&gad_source=1&gad_campaignid=7993749347&gbraid=0AAAAADn4z6gHcJduDz_4dLVEw2Vc9I-lF&gclid=Cj0KCQjwrPHABhCIARIsAFW2XBOh1fGjHUcrDUDTaKTms6Qyrpi6Vo80Jj9_StfCFnEjiR_REi9zoZEaAjFjEALw_wcB)
 </Info>
+<Warning>
+  We recommend that you **only link your Zendesk account with one bot**. Linking the same Zendesk account with multiple bots will raise an error and cause unexpected behaviour.
+</Warning>
 
 <Steps titleSize="h3">
   <Step title="Add the Zendesk Integration">


### PR DESCRIPTION
Adds a warning against using multiple bots with the Zendesk integration.