### PR TITLE
feat(integrations/gmail): add gmail guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -272,6 +272,10 @@
             "group": "Integration Guides",
             "pages": [
               "/integrations/integration-guides/asana",
+              "/integrations/integration-guides/chat",
+              "/integrations/integration-guides/gmail",
+              "/integrations/integration-guides/google-calendar",
+              "/integrations/integration-guides/google-sheet",
               "/integrations/integration-guides/hitl",
               "/integrations/integration-guides/instagram",
               "/integrations/integration-guides/intercom",
@@ -309,10 +313,7 @@
                 ]
               },
               "/integrations/integration-guides/zapier",
-              "/integrations/integration-guides/zendesk",
-              "/integrations/integration-guides/chat",
-              "/integrations/integration-guides/google-sheet",
-              "/integrations/integration-guides/google-calendar"
+              "/integrations/integration-guides/zendesk"
             ]
           }
         ]

--- a/integrations/integration-guides/gmail.mdx
+++ b/integrations/integration-guides/gmail.mdx
@@ -184,7 +184,9 @@ Due to the sensitive nature of email communication, the Gmail integration requir
         https://accounts.google.com/o/oauth2/auth?response_type=code&scope=https://www.googleapis.com/auth/gmail.readonly%20https://www.googleapis.com/auth/gmail.send&access_type=offline&prompt=consent&redirect_uri=https://botpress.com&client_id=
         `
 
-        > Make sure to add your OAuth **Client ID** from [Step 4](#step-4-create-oauth-credentials) to the end of the URL. For example, if your OAuth client ID is `abcd`, the URL should end with `&client_id=abcd`.
+        <Note>
+        Make sure to add your OAuth **Client ID** from [Step 4](#step-4-create-oauth-credentials) to the end of the URL. For example, if your OAuth client ID is `abcd`, the URL should end with `&client_id=abcd`.
+        </Note>
 
         3. Follow the on-screen instructions to authorize the OAuth application with your personal Gmail account.
 
@@ -208,7 +210,7 @@ Due to the sensitive nature of email communication, the Gmail integration requir
         4. Fill in the required fields with all the information you saved from the previous steps.
 
         <Warning>
-        The authorization code is only valid for a short period of time. If the code has expired, you will need to repeat the steps outlined in the [Authorize the OAuth application](#authorize-the-oauth-application) section.
+        The authorization code is only valid for a short period of time. If the code has expired, you will need to repeat the steps outlined in [Step 10](#step-10-authorize-the-oauth-application).
         </Warning>
 
         10. Select **Save Configuration**. If no error message is displayed, the integration was successfully configured.

--- a/integrations/integration-guides/gmail.mdx
+++ b/integrations/integration-guides/gmail.mdx
@@ -1,0 +1,233 @@
+The Gmail integration allows your bot to chat with users via your Gmail address.
+
+<Danger>
+    Once you've successfully configured the Gmail integration, **the email address you provided will begin responding to all incoming emails as your bot**. Please be aware of this behaviour before configuring the integration.
+</Danger>
+
+## Setup
+
+Due to the sensitive nature of email communication, the Gmail integration requires a secure connection between Botpress and Gmail. To establish this secure connection, you need to configure the Gmail integration using OAuth.
+
+<Tabs>
+    <Tab title="Automatic configuration">
+        <Warning>
+            ### Automatic configuration is temporarily unavailable
+
+            The Gmail integration is currently undergoing a verification process by Google. This means the option to automatically configure your Gmail integration is temporarily unavailable.
+
+            You can still setup the integration using [manual configuration](#manual-configuration).
+
+            {/* ### Automatic configuration with OAuth
+
+            To set up the Gmail integration using OAuth, click the authorization button and follow the on-screen instructions to connect your Botpress chatbot to Gmail.
+
+            When using this configuration mode, a Botpress-managed Gmail application will be used to connect to your Gmail account. However, actions taken by the bot will be attributed to the user who authorized the connection, rather than the application. For this reason, **we do not recommend using personal Gmail accounts** for this integration. You should set up a service account and use this account to authorize the connection.
+
+            #### Configuring the integration in Botpress
+
+            1. Authorize the Gmail integration by clicking the authorization button.
+            2. Follow the on-screen instructions to connect your Botpress chatbot to Gmail.
+            3. Once the connection is established, you can save the configuration and enable the integration. */}
+        </Warning>
+    </Tab>
+    <Tab title="Manual configuration">
+        <Info>
+            You will need:
+
+            - A [Gmail account](https://accounts.google.com/lifecycle/steps/signup/name?dsh=S488568382:1750873665808135&flowEntry=SignUp&flowName=GlifWebSignIn&ifkv=AdBytiOTk616W0u9QbXQoFbPYoR1Qt9WGXLoe9KHjswYWHiW2YTuLodd-4Obm8grx6EQIpFLKcluuQ&TL=ALgCv6xtJQTT14EXPydgMeNRTVl3Q1ie-kqOs_0vn7uPY_I47_GueZAXRwuHK72t&continue=https://accounts.google.com/ManageAccount?nc%3D1)
+        </Info>
+
+        ### Step 1. Create a Google Cloud Platform project
+
+        1. Login to [Google Cloud Console](https://console.cloud.google.com/) with your Gmail account.
+        2. Select **Select a project** dropdown in the top navigation. Then, select **New Project**.
+        3. Follow the on-screen instructions to create the new project.
+
+        ### Step 2. Enable the Gmail API
+
+        1. In Google Cloud Console, navigate to the *APIs & Services* section.
+        2. Select **Library** from the left sidebar.
+        3. Search for **Gmail API** and select the result.
+        4. Select **Enable** to enable the Gmail API for your project.
+
+        ### Step 3. Configure the OAuth consent screen
+
+        1. In Google Cloud Console, navigate to the **APIs & Services** section.
+        2. Select **OAuth consent screen** in the left sidebar.
+        3. Select **Get Started** and fill out the **App Information** section. Then, select *Next*.
+        4. Under **Audience**, select **External**
+        5. Fill in the other required sections, then select **Create**.
+        6. Navigate to the **Data Access** tab, then select **Add or remove scopes**.
+        7. Under `Manually add scopes`, enter the following:
+
+        ```plaintext
+        https://www.googleapis.com/auth/userinfo.email
+        https://www.googleapis.com/auth/userinfo.profile
+        https://www.googleapis.com/auth/gmail.readonly
+        https://www.googleapis.com/auth/gmail.send
+        ```
+
+        8. Select **Add to table**, then **Update**.
+        9. Select **Save** at the bottom of the screen.
+        10. Navigate to the **Audience** tab. Under **Test users**, select ** + Add users**.
+        11. Add an email address for testing the app, then select **Save**.
+
+        ### Step 4. Create OAuth credentials
+
+        1. In Google Cloud Console, navigate to the **APIs & Services** section.
+        2. Select **Credentials** in the left sidebar.
+        3. Select **Create credentials**, then **OAuth client ID**.
+        4. Select **Web application** as the application type.
+        5. Enter a name for the OAuth client ID.
+        6. Under **Authorized redirect URIs**, enter `https://botpress.com`.
+        7. Select **Add URI**, then **Create**.
+        8. Copy the **Client ID** and **Client secret** for use in the next steps.
+        
+        <Note>
+        The client ID is the string that ends with `.apps.googleusercontent.com`.
+        </Note>
+
+        ### Step 5. Create a service account
+
+        1. In Google Cloud Console, navigate to the **IAM & Admin** section.
+        2. Select **Service accounts** in the left sidebar.
+        3. Select **Create service account**.
+        4. Enter a name for the service account. Then, select **Done**.
+
+        <Note>
+        You don't need to grant any roles to the service account, as it will only be used to sign webhook events.
+        </Note>
+
+        6. Copy the service account email address for use in the next steps.
+
+        <Tip>
+        The service account email address is the string that ends with `.gserviceaccount.com`.
+        </Tip>
+
+        ### Step 6. Create a Pub/Sub topic
+
+        1. In Google Cloud Console, search for and navigate to the **Pub/Sub** section.
+        2. Select **Topics** in the left sidebar.
+        3. Select **Create topic**.
+        4. Enter a name for the topic in the **Topic ID** field.
+        5. Uncheck the **Add default subscription** checkbox. Leave the other options unchanged.
+        7. Select **Create** to create the topic.
+        8. Copy the **Topic name** for use in the next steps.
+        
+        <Note>
+        The topic name is the string that starts with `projects/`.
+        </Note>
+
+        ### Step 7. Grant publish rights on the Pub/Sub topic
+
+        1. In Google Cloud Console, search for and navigate to the **Pub/Sub** section.
+        2. Select **Topics** in the left sidebar.
+        3. From the topic list, find the topic you created earlier. Then, select the triple-dot <kbd>⋮</kbd> button on the right.
+        4. Select **View permissions** from the dropdown menu.
+        5. Select **Add principal**.
+        6. Under **Add principals**, enter `gmail-api-push@system.gserviceaccount.com`.
+
+        <Note>
+        This service account is managed by Google and is used to push events to Pub/Sub.
+        </Note>
+
+        7. Under **Assign roles**, select `Pub/Sub Publisher`.
+        8. Select **Save** to grant publish rights to the service account.
+
+        ### Step 8. Generate a shared secret
+
+        1. Generate an alphanumeric string to use as a shared secret for signing Pub/Sub push events. We recommend using a string with at least 32 characters.
+        
+        <Tip>
+        You can use an [online password generator](https://bitwarden.com/password-generator/) to create a secure string.
+        </Tip>
+
+        2. Copy this string for use in the next steps.
+
+        ### Step 9. Create a Pub/Sub subscription
+
+        1. In **Google Cloud Console**, search for and navigate to the **Pub/Sub** section.
+        2. Select **Subscriptions** in the left sidebar.
+        3. Select **Create subscription**.
+        4. Enter a name for the subscription in the **Subscription ID** field.
+        5. Select the topic you created earlier from the topic dropdown.
+        6. Under **Delivery type**, select **Push**.
+        7. Enter your integration's Botpress-provided webhook URL in the **Endpoint URL** field. To this URL, add `?shared_secret=`, followed by the shared secret you generated earlier.
+
+        <Tip>
+        For example, if:
+        
+        - Your integration's webhook URL is: `https://webhook.botpress.cloud/57fcfb04-51fd-4381-909a-10e6ae53d310`
+        - Your shared secret is `Ut5hzrxs7uV87mzCAKL3ztrzesWWBiNa`
+        
+        You would enter:
+        
+        `https://webhook.botpress.cloud/57fcfb04-51fd-4381-909a-10e6ae53d310?shared_secret=Ut5hzrxs7uV87mzCAKL3ztrzesWWBiNa`
+        
+        in the **Endpoint URL** field.
+        </Tip>
+
+        8. Check the **Enable authentication** checkbox.
+        9. Select the service account email address you created earlier in the **Service account** field.
+        10. Enter the shared secret you generated earlier in the `Audience` field.
+        11. Under **Expiration period**, select **Never expire**.
+        12. Under **Acknowledgement deadline**, enter 60 seconds.
+        13. Under **Retry policy**, select **Retry after exponential backoff delay**. Set the minimum backoff to 60 seconds and the maximum backoff to 600 seconds.
+        14. Select **Create** to create the subscription.
+
+        ### Step 10. Authorize the OAuth application
+
+        1. On Gmail, log in to the Google account you want to use with the Gmail integration.
+        2. Once logged in, go to the following URL in your browser:
+
+        `
+        https://accounts.google.com/o/oauth2/auth?response_type=code&scope=https://www.googleapis.com/auth/gmail.readonly%20https://www.googleapis.com/auth/gmail.send&access_type=offline&prompt=consent&redirect_uri=https://botpress.com&client_id=
+        `
+
+        > Make sure to add your OAuth **Client ID** from [Step 4](#step-4-create-oauth-credentials) to the end of the URL. For example, if your OAuth client ID is `abcd`, the URL should end with `&client_id=abcd`.
+
+        3. Follow the on-screen instructions to authorize the OAuth application with your personal Gmail account.
+
+        <Warning>
+            After completing the authorization, you will be redirected to [botpress.com](https://botpress.com). Do not close this page.
+        </Warning>
+
+        4. Copy the **authorization code** from the URL in your browser's address bar. The authorization code is the string that appears after `code=` and before `&scope=` in the URL.
+
+        <Tip>
+        If you have difficulty finding the authorization code in the URL, you can use online tools like https://semalt.tools/en/url-parser or https://parseurlonline.com.
+        </Tip>
+
+        5. You can now safely close this page.
+
+        ### Step 11. Configure the integration in Botpress
+
+        1. In Botpress Studio, select **Explore Hub** in the upper-right corner.
+        2. Search for the **Gmail** integration, then select **Install Integration**.
+        3. In the Configuration menu, select **Configure manually with your own GCP App**.
+        4. Fill in the required fields with all the information you saved from the previous steps.
+
+        <Warning>
+        The authorization code is only valid for a short period of time. If the code has expired, you will need to repeat the steps outlined in the [Authorize the OAuth application](#authorize-the-oauth-application) section.
+        </Warning>
+
+        10. Select **Save Configuration**. If no error message is displayed, the integration was successfully configured.
+    </Tab>
+</Tabs>
+
+## Limitations
+
+<AccordionGroup>
+    <Accordion
+        title="Costs"
+    >
+        Botpress shall not be held responsible for any costs you may incur on the Google Cloud Platform while using the Gmail integration, should you choose to use the manual configuration mode. Ensure that you are aware of the costs associated with using the Gmail API and the Google Cloud Platform before using the manual configuration mode.
+    </Accordion>
+    <Accordion
+        title="API limits"
+    >
+       Standard Gmail API limitations apply to the Gmail integration in Botpress. These limitations include rate limits, message size restrictions, and other constraints imposed by the Gmail and Google Cloud platforms. Ensure that your chatbot adheres to these limitations to maintain optimal performance and reliability.
+
+        More details are available in the [Gmail API documentation](https://developers.google.com/gmail/api/reference/quota).
+    </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
Adds a guide for the Gmail integration. It's basically a souped-up version of the integration's hub.md, but newly tested and tidied up (with a few relevant disclaimers — this integration's behaviour is super screwed up at the moment). Oh and I alphabetized the integration guides.