### PR TITLE
fix(agents/vision): add callout

### DIFF
--- a/learn/reference/agents/vision-agent.mdx
+++ b/learn/reference/agents/vision-agent.mdx
@@ -5,15 +5,19 @@ description: Adds image recognition and visual processing capabilities to your b
 
 The Vision Agent adds image recognition and visual processing capabilities to the bot. It allows the bot to analyze and interpret visual data, such as images, screenshots, or camera feeds.
 
-# Configuration
+<Note>
+    To use the Vision Agent, you need to enable **Extract from Incoming Images** in your [Autonomous Node's configuration](/learn/reference/nodes/autonomous-node#configuration).
+</Note>
 
-## Extract from Incoming Images
+## Configuration
+
+### Extract from Incoming Images
 
 When this option is enabled, the bot will attempt to extract any text content from an image. It will also produce a description of the image itself.
 
 The Vision Agent will save any extracted content and descriptions to the variable it exposes.
 
-# Exposed Variables
+### Exposed Variables
 
 The Vision Agent exposes one variable for use:
 


### PR DESCRIPTION
Adds a callout to mention that Vision Agent won't work unless the AN is configured to use it.