### PR TITLE
fix(api/playground): add missing headers

### DIFF
--- a/admin-openapi.json
+++ b/admin-openapi.json
@@ -1998,6 +1998,18 @@
     }
   },
   "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "WorkspaceIdHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-workspace-id",
+        "description": "Your workspace ID."
+      }
+    },
     "schemas": {
       "Bot": {
         "type": "object",
@@ -10256,5 +10268,11 @@
       }
     },
     "parameters": {}
-  }
+  },
+  "security": [
+      {
+        "BearerAuth": [],
+        "WorkspaceIdHeader": []
+      }
+    ]
 }

--- a/files-openapi.json
+++ b/files-openapi.json
@@ -495,6 +495,18 @@
         }
     },
     "components": {
+        "securitySchemes": {
+            "BearerAuth": {
+                "type": "http",
+                "scheme": "bearer"
+            },
+            "BotIdHeader": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "x-bot-id",
+                "description": "Your bot ID."
+            }
+        },
         "schemas": {
             "File": {
                 "type": "object",
@@ -2189,12 +2201,12 @@
                     }
                 }
             }
-        },
-        "parameters": {
-            "test": {
-                "name": "test",
-                "in": "header"
-            }
         }
-    }
+    },
+    "security": [
+        {
+            "BearerAuth": [],
+            "BotIdHeader": []
+        }
+    ]
 }

--- a/files-openapi.json
+++ b/files-openapi.json
@@ -1,1 +1,2200 @@
-{"openapi":"3.0.0","servers":[{"url":"https://api.botpress.cloud"}],"info":{"title":"Botpress Files API","description":"API for Files","version":"0.18.0"},"paths":{"/v1/files":{"put":{"operationId":"upsertFile","description":"Creates or updates a file using the `key` parameter as unique identifier. Updating a file will erase the existing content of the file. Upload the file content by sending it in a PUT request to the `uploadUrl` returned in the response.","parameters":[],"responses":{"200":{"$ref":"#/components/responses/upsertFileResponse"},"default":{"$ref":"#/components/responses/upsertFileResponse"}},"requestBody":{"$ref":"#/components/requestBodies/upsertFileBody"}},"get":{"operationId":"listFiles","description":"List files for bot","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"sortField","in":"query","description":"Sort results by this field","schema":{"type":"string","enum":["key","size","createdAt","updatedAt","status"]}},{"name":"sortDirection","in":"query","description":"Sort results in this direction","schema":{"type":"string","enum":["asc","desc"]}},{"name":"tags","in":"query","description":"Filter files by tags. Tags should be passed as a URL-encoded JSON object of key-value pairs that must be present in the tags of a file. An array of multiple string values for the same key are treated as an OR condition. To exclude a value, express it as an object with a nested `not` key with the string or string-array value(s) to exclude.","schema":{}},{"name":"ids","in":"query","description":"Filter files by IDs.","schema":{"type":"array","items":{"type":"string"},"maxItems":50}}],"responses":{"200":{"$ref":"#/components/responses/listFilesResponse"},"default":{"$ref":"#/components/responses/listFilesResponse"}}}},"/v1/files/{id}":{"delete":{"operationId":"deleteFile","description":"Deletes a file.","parameters":[{"name":"id","in":"path","description":"File ID or Key","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/deleteFileResponse"},"default":{"$ref":"#/components/responses/deleteFileResponse"}}},"get":{"operationId":"getFile","description":"Get file","parameters":[{"name":"id","in":"path","description":"File ID or Key","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/getFileResponse"},"default":{"$ref":"#/components/responses/getFileResponse"}}},"put":{"operationId":"updateFileMetadata","description":"Update file metadata, without updating the file content.","parameters":[{"name":"id","in":"path","description":"File ID or Key","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/updateFileMetadataResponse"},"default":{"$ref":"#/components/responses/updateFileMetadataResponse"}},"requestBody":{"$ref":"#/components/requestBodies/updateFileMetadataBody"}}},"/v1/files/{idOrKey}/{destinationKey}":{"post":{"operationId":"copyFile","description":"Copy file","parameters":[{"name":"idOrKey","in":"path","description":"File ID or Key","required":true,"schema":{"type":"string"}},{"name":"destinationKey","in":"path","description":"The new key of the file. The file key must not be in use already in the destination bot.","required":true,"schema":{"type":"string"}},{"name":"x-destination-bot-id","in":"header","description":"The bot ID to copy the file to. You must have permission to create files in the destination bot. If the destination bot ID is omitted, the file will be copied to the same bot the source file belongs to.","schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/copyFileResponse"},"default":{"$ref":"#/components/responses/copyFileResponse"}},"requestBody":{"$ref":"#/components/requestBodies/copyFileBody"}}},"/v1/files/search":{"get":{"operationId":"searchFiles","description":"Search files","parameters":[{"name":"tags","in":"query","description":"Filter files by tags. Tags should be passed as a URL-encoded JSON object of key-value pairs that must be present in the tags of a file. An array of multiple string values for the same key are treated as an OR condition. To exclude a value, express it as an object with a nested `not` key with the string or string-array value(s) to exclude.","schema":{}},{"name":"query","in":"query","description":"Query expressed in natural language to retrieve matching text passages within all indexed files in the bot using semantical search.","required":true,"schema":{"type":"string"}},{"name":"contextDepth","in":"query","description":"The number of neighbor passages to prepend and append as surrounding context to the content of each returned passage (default: 1, minimum: 0, maximum: 10).","schema":{"type":"integer"}},{"name":"limit","in":"query","description":"The maximum number of passages to return.","schema":{"type":"integer"}},{"name":"consolidate","in":"query","description":"Consolidate the results by merging matching passages from the same file into a single passage per file. The consolidated passage will include the matching passages ordered by their original position in the file (rather than by relevance score) and include hierarchical context such as the title/subtitle to which they belong.","schema":{"type":"boolean"}},{"name":"includeBreadcrumb","in":"query","description":"Prepend a breadcrumb to each passage, containing the title and subtitle(s) the passage belongs to in the file. This option is ignored when the `consolidate` option is set to `true`.","schema":{"type":"boolean"}}],"responses":{"200":{"$ref":"#/components/responses/searchFilesResponse"},"default":{"$ref":"#/components/responses/searchFilesResponse"}}}},"/v1/files/{id}/passages":{"get":{"operationId":"listFilePassages","description":"List passages for a file","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"id","in":"path","description":"File ID or Key","required":true,"schema":{"type":"string"}},{"name":"limit","in":"query","description":"The maximum number of passages to return per request (optional, default: 20, max: 200).","schema":{"type":"number"}}],"responses":{"200":{"$ref":"#/components/responses/listFilePassagesResponse"},"default":{"$ref":"#/components/responses/listFilePassagesResponse"}}},"put":{"operationId":"setFilePassages","description":"Sets the indexed file passages asynchronously. All existing indexed passages will be deleted as soon as the indexing begins. This endpoint will return immediately and set the file status to \"indexing_pending\". Once the new passages are indexed the file status will be set to \"indexing_completed\", or \"indexing_failed\" if the passages failed to be indexed.","parameters":[{"name":"id","in":"path","description":"File ID or Key","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/setFilePassagesResponse"},"default":{"$ref":"#/components/responses/setFilePassagesResponse"}},"requestBody":{"$ref":"#/components/requestBodies/setFilePassagesBody"}}},"/v1/files/tags":{"get":{"operationId":"listFileTags","description":"List available tags","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/listFileTagsResponse"},"default":{"$ref":"#/components/responses/listFileTagsResponse"}}}},"/v1/files/tags/{tag}/values":{"get":{"operationId":"listFileTagValues","description":"List available tags","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"tag","in":"path","description":"Tag name","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/listFileTagValuesResponse"},"default":{"$ref":"#/components/responses/listFileTagValuesResponse"}}}},"/v1/files/knowledge-bases":{"post":{"operationId":"createKnowledgeBase","description":"Creates a knowledge base for grouping files.","parameters":[],"responses":{"200":{"$ref":"#/components/responses/createKnowledgeBaseResponse"},"default":{"$ref":"#/components/responses/createKnowledgeBaseResponse"}},"requestBody":{"$ref":"#/components/requestBodies/createKnowledgeBaseBody"}},"get":{"operationId":"listKnowledgeBases","description":"List knowledge bases for bot","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/listKnowledgeBasesResponse"},"default":{"$ref":"#/components/responses/listKnowledgeBasesResponse"}}}},"/v1/files/knowledge-bases/{id}":{"delete":{"operationId":"deleteKnowledgeBase","description":"Deletes a knowledge base.","parameters":[{"name":"id","in":"path","description":"Knowledge base ID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/deleteKnowledgeBaseResponse"},"default":{"$ref":"#/components/responses/deleteKnowledgeBaseResponse"}}},"put":{"operationId":"updateKnowledgeBase","description":"Updates a knowledge base.","parameters":[{"name":"id","in":"path","description":"Knowledge base ID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/updateKnowledgeBaseResponse"},"default":{"$ref":"#/components/responses/updateKnowledgeBaseResponse"}},"requestBody":{"$ref":"#/components/requestBodies/updateKnowledgeBaseBody"}}}},"components":{"schemas":{"File":{"type":"object","properties":{"id":{"type":"string","description":"File ID"},"botId":{"type":"string","description":"The ID of the bot the file belongs to"},"key":{"type":"string","description":"Unique key for the file. Must be unique across the bot (and the integration, when applicable)."},"url":{"type":"string","description":"URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."},"size":{"type":"number","description":"File size in bytes. Non-null if file upload status is \"COMPLETE\".","nullable":true},"contentType":{"type":"string","description":"MIME type of the file's content"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":1000},"description":"The tags of the file as an object of key/value pairs"},"metadata":{"type":"object","additionalProperties":{"nullable":true},"description":"Metadata of the file as an object of key/value pairs. The values can be of any type."},"createdAt":{"type":"string","description":"File creation timestamp in ISO 8601 format"},"updatedAt":{"type":"string","description":"File last update timestamp in ISO 8601 format"},"accessPolicies":{"type":"array","items":{"type":"string","enum":["integrations","public_content"]},"description":"Access policies configured for the file."},"index":{"type":"boolean","description":"Whether the file was requested to be indexed for search or not."},"status":{"type":"string","enum":["upload_pending","upload_failed","upload_completed","indexing_pending","indexing_failed","indexing_completed"],"description":"Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."},"failedStatusReason":{"type":"string","description":"If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."},"expiresAt":{"type":"string","description":"File expiry timestamp in ISO 8601 format"},"owner":{"type":"object","properties":{"type":{"type":"string","enum":["bot","integration","user"]},"id":{"type":"string","description":"This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."},"name":{"type":"string","description":"This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."}},"required":["type"],"additionalProperties":false}},"required":["id","botId","key","url","size","contentType","tags","metadata","createdAt","updatedAt","accessPolicies","index","status","owner"],"additionalProperties":false}},"responses":{"upsertFileResponse":{"description":"The created or updated file","content":{"application/json":{"schema":{"type":"object","properties":{"file":{"type":"object","properties":{"id":{"type":"string","description":"File ID"},"botId":{"type":"string","description":"The ID of the bot the file belongs to"},"key":{"type":"string","description":"Unique key for the file. Must be unique across the bot (and the integration, when applicable)."},"url":{"type":"string","description":"URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."},"size":{"type":"number","description":"File size in bytes. Non-null if file upload status is \"COMPLETE\".","nullable":true},"contentType":{"type":"string","description":"MIME type of the file's content"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":1000},"description":"The tags of the file as an object of key/value pairs"},"metadata":{"type":"object","additionalProperties":{"nullable":true},"description":"Metadata of the file as an object of key/value pairs. The values can be of any type."},"createdAt":{"type":"string","description":"File creation timestamp in ISO 8601 format"},"updatedAt":{"type":"string","description":"File last update timestamp in ISO 8601 format"},"accessPolicies":{"type":"array","items":{"type":"string","enum":["integrations","public_content"]},"description":"Access policies configured for the file."},"index":{"type":"boolean","description":"Whether the file was requested to be indexed for search or not."},"status":{"type":"string","enum":["upload_pending","upload_failed","upload_completed","indexing_pending","indexing_failed","indexing_completed"],"description":"Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."},"failedStatusReason":{"type":"string","description":"If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."},"expiresAt":{"type":"string","description":"File expiry timestamp in ISO 8601 format"},"owner":{"type":"object","properties":{"type":{"type":"string","enum":["bot","integration","user"]},"id":{"type":"string","description":"This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."},"name":{"type":"string","description":"This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."}},"required":["type"],"additionalProperties":false},"uploadUrl":{"type":"string","description":"URL to upload the file content. File content needs to be sent to this URL via a PUT request."}},"required":["id","botId","key","url","size","contentType","tags","metadata","createdAt","updatedAt","accessPolicies","index","status","owner","uploadUrl"],"additionalProperties":false}},"required":["file"],"title":"upsertFileResponse","additionalProperties":false}}}},"deleteFileResponse":{"description":"Empty response.","content":{"application/json":{"schema":{"type":"object","title":"deleteFileResponse","additionalProperties":false}}}},"listFilesResponse":{"description":"Returns the list of files related to the bot.","content":{"application/json":{"schema":{"type":"object","properties":{"files":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"File ID"},"botId":{"type":"string","description":"The ID of the bot the file belongs to"},"key":{"type":"string","description":"Unique key for the file. Must be unique across the bot (and the integration, when applicable)."},"url":{"type":"string","description":"URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."},"size":{"type":"number","description":"File size in bytes. Non-null if file upload status is \"COMPLETE\".","nullable":true},"contentType":{"type":"string","description":"MIME type of the file's content"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":1000},"description":"The tags of the file as an object of key/value pairs"},"metadata":{"type":"object","additionalProperties":{"nullable":true},"description":"Metadata of the file as an object of key/value pairs. The values can be of any type."},"createdAt":{"type":"string","description":"File creation timestamp in ISO 8601 format"},"updatedAt":{"type":"string","description":"File last update timestamp in ISO 8601 format"},"accessPolicies":{"type":"array","items":{"type":"string","enum":["integrations","public_content"]},"description":"Access policies configured for the file."},"index":{"type":"boolean","description":"Whether the file was requested to be indexed for search or not."},"status":{"type":"string","enum":["upload_pending","upload_failed","upload_completed","indexing_pending","indexing_failed","indexing_completed"],"description":"Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."},"failedStatusReason":{"type":"string","description":"If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."},"expiresAt":{"type":"string","description":"File expiry timestamp in ISO 8601 format"},"owner":{"type":"object","properties":{"type":{"type":"string","enum":["bot","integration","user"]},"id":{"type":"string","description":"This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."},"name":{"type":"string","description":"This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."}},"required":["type"]}},"required":["id","botId","key","url","size","contentType","tags","metadata","createdAt","updatedAt","accessPolicies","index","status","owner"]}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["files","meta"],"title":"listFilesResponse","additionalProperties":false}}}},"getFileResponse":{"description":"An object containing the file metadata and URL","content":{"application/json":{"schema":{"type":"object","properties":{"file":{"type":"object","properties":{"id":{"type":"string","description":"File ID"},"botId":{"type":"string","description":"The ID of the bot the file belongs to"},"key":{"type":"string","description":"Unique key for the file. Must be unique across the bot (and the integration, when applicable)."},"url":{"type":"string","description":"URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."},"size":{"type":"number","description":"File size in bytes. Non-null if file upload status is \"COMPLETE\".","nullable":true},"contentType":{"type":"string","description":"MIME type of the file's content"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":1000},"description":"The tags of the file as an object of key/value pairs"},"metadata":{"type":"object","additionalProperties":{"nullable":true},"description":"Metadata of the file as an object of key/value pairs. The values can be of any type."},"createdAt":{"type":"string","description":"File creation timestamp in ISO 8601 format"},"updatedAt":{"type":"string","description":"File last update timestamp in ISO 8601 format"},"accessPolicies":{"type":"array","items":{"type":"string","enum":["integrations","public_content"]},"description":"Access policies configured for the file."},"index":{"type":"boolean","description":"Whether the file was requested to be indexed for search or not."},"status":{"type":"string","enum":["upload_pending","upload_failed","upload_completed","indexing_pending","indexing_failed","indexing_completed"],"description":"Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."},"failedStatusReason":{"type":"string","description":"If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."},"expiresAt":{"type":"string","description":"File expiry timestamp in ISO 8601 format"},"owner":{"type":"object","properties":{"type":{"type":"string","enum":["bot","integration","user"]},"id":{"type":"string","description":"This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."},"name":{"type":"string","description":"This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."}},"required":["type"],"additionalProperties":false}},"required":["id","botId","key","url","size","contentType","tags","metadata","createdAt","updatedAt","accessPolicies","index","status","owner"],"additionalProperties":false}},"required":["file"],"title":"getFileResponse","additionalProperties":false}}}},"updateFileMetadataResponse":{"description":"An object containing the updated file metadata.","content":{"application/json":{"schema":{"type":"object","properties":{"file":{"type":"object","properties":{"id":{"type":"string","description":"File ID"},"botId":{"type":"string","description":"The ID of the bot the file belongs to"},"key":{"type":"string","description":"Unique key for the file. Must be unique across the bot (and the integration, when applicable)."},"url":{"type":"string","description":"URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."},"size":{"type":"number","description":"File size in bytes. Non-null if file upload status is \"COMPLETE\".","nullable":true},"contentType":{"type":"string","description":"MIME type of the file's content"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":1000},"description":"The tags of the file as an object of key/value pairs"},"metadata":{"type":"object","additionalProperties":{"nullable":true},"description":"Metadata of the file as an object of key/value pairs. The values can be of any type."},"createdAt":{"type":"string","description":"File creation timestamp in ISO 8601 format"},"updatedAt":{"type":"string","description":"File last update timestamp in ISO 8601 format"},"accessPolicies":{"type":"array","items":{"type":"string","enum":["integrations","public_content"]},"description":"Access policies configured for the file."},"index":{"type":"boolean","description":"Whether the file was requested to be indexed for search or not."},"status":{"type":"string","enum":["upload_pending","upload_failed","upload_completed","indexing_pending","indexing_failed","indexing_completed"],"description":"Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."},"failedStatusReason":{"type":"string","description":"If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."},"expiresAt":{"type":"string","description":"File expiry timestamp in ISO 8601 format"},"owner":{"type":"object","properties":{"type":{"type":"string","enum":["bot","integration","user"]},"id":{"type":"string","description":"This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."},"name":{"type":"string","description":"This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."}},"required":["type"],"additionalProperties":false}},"required":["id","botId","key","url","size","contentType","tags","metadata","createdAt","updatedAt","accessPolicies","index","status","owner"],"additionalProperties":false}},"required":["file"],"title":"updateFileMetadataResponse","additionalProperties":false}}}},"copyFileResponse":{"description":"An object containing the file metadata and URL","content":{"application/json":{"schema":{"type":"object","properties":{"file":{"type":"object","properties":{"id":{"type":"string","description":"File ID"},"botId":{"type":"string","description":"The ID of the bot the file belongs to"},"key":{"type":"string","description":"Unique key for the file. Must be unique across the bot (and the integration, when applicable)."},"url":{"type":"string","description":"URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."},"size":{"type":"number","description":"File size in bytes. Non-null if file upload status is \"COMPLETE\".","nullable":true},"contentType":{"type":"string","description":"MIME type of the file's content"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":1000},"description":"The tags of the file as an object of key/value pairs"},"metadata":{"type":"object","additionalProperties":{"nullable":true},"description":"Metadata of the file as an object of key/value pairs. The values can be of any type."},"createdAt":{"type":"string","description":"File creation timestamp in ISO 8601 format"},"updatedAt":{"type":"string","description":"File last update timestamp in ISO 8601 format"},"accessPolicies":{"type":"array","items":{"type":"string","enum":["integrations","public_content"]},"description":"Access policies configured for the file."},"index":{"type":"boolean","description":"Whether the file was requested to be indexed for search or not."},"status":{"type":"string","enum":["upload_pending","upload_failed","upload_completed","indexing_pending","indexing_failed","indexing_completed"],"description":"Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."},"failedStatusReason":{"type":"string","description":"If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."},"expiresAt":{"type":"string","description":"File expiry timestamp in ISO 8601 format"},"owner":{"type":"object","properties":{"type":{"type":"string","enum":["bot","integration","user"]},"id":{"type":"string","description":"This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."},"name":{"type":"string","description":"This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."}},"required":["type"],"additionalProperties":false}},"required":["id","botId","key","url","size","contentType","tags","metadata","createdAt","updatedAt","accessPolicies","index","status","owner"],"additionalProperties":false}},"required":["file"],"title":"copyFileResponse","additionalProperties":false}}}},"searchFilesResponse":{"description":"Returns the text passages within all indexed files that matched the query.","content":{"application/json":{"schema":{"type":"object","properties":{"passages":{"type":"array","items":{"type":"object","properties":{"content":{"type":"string","description":"The content of the matching passage in the file including surrounding context, if any."},"score":{"type":"number","description":"The score indicating the similarity of the passage to the query. A higher score indicates higher similarity."},"meta":{"type":"object","properties":{"type":{"type":"string","enum":["chunk","summary","consolidated","image"],"description":"The type of passage"},"subtype":{"type":"string","enum":["title","subtitle","paragraph","blockquote","list","table","code","image","page"],"description":"The subtype of passage, if available."},"pageNumber":{"type":"integer","description":"Page number the passage is located on. Only applicable if the passage was extracted from a PDF file."},"position":{"type":"integer","description":"Position number of the passage in the file relative to the other passages, if available. Can be used to know the order of passages within a file."},"sourceUrl":{"type":"string","format":"uri","description":"The URL of the source file for the vector, if applicable (e.g. for image vectors)."}},"description":"The passage metadata."},"file":{"type":"object","properties":{"id":{"type":"string","description":"File ID"},"key":{"type":"string","description":"Unique key for the file. Must be unique across the bot (and the integration, when applicable)."},"contentType":{"type":"string","description":"MIME type of the file's content"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":1000},"description":"The tags of the file as an object of key-value pairs."},"createdAt":{"type":"string","description":"File creation timestamp in ISO 8601 format"},"updatedAt":{"type":"string","description":"File last update timestamp in ISO 8601 format"}},"required":["id","key","contentType","tags","createdAt","updatedAt"]},"context":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","format":"uuid"},"text":{"type":"string"},"offset":{"type":"integer","description":"Position of the context passage relative to the current passage. Negative for preceding passages, positive for subsequent, ommited for breadcrumbs."},"type":{"type":"string","enum":["preceding","subsequent","breadcrumb"],"description":"The type of context passage"}},"required":["id","text","type"]}}},"required":["content","score","meta","file"]}}},"required":["passages"],"title":"searchFilesResponse","additionalProperties":false}}}},"listFilePassagesResponse":{"description":"Returns the list of passages extracted from a file.","content":{"application/json":{"schema":{"type":"object","properties":{"passages":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"Passage ID"},"content":{"type":"string","description":"The content of the passage."},"meta":{"type":"object","properties":{"type":{"type":"string","enum":["chunk","summary","consolidated","image"],"description":"The type of passage"},"subtype":{"type":"string","enum":["title","subtitle","paragraph","blockquote","list","table","code","image","page"],"description":"The subtype of passage, if available."},"pageNumber":{"type":"integer","description":"Page number the passage is located on. Only applicable if the passage was extracted from a PDF file."},"position":{"type":"integer","description":"Position number of the passage in the file relative to the other passages, if available. Can be used to know the order of passages within a file."},"sourceUrl":{"type":"string","format":"uri","description":"The URL of the source file for the vector, if applicable (e.g. for image vectors)."}},"description":"The passage metadata."}},"required":["id","content","meta"]}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["passages","meta"],"title":"listFilePassagesResponse","additionalProperties":false}}}},"setFilePassagesResponse":{"description":"Empty response.","content":{"application/json":{"schema":{"type":"object","title":"setFilePassagesResponse","additionalProperties":false}}}},"listFileTagsResponse":{"description":"Returns the list of available tags used across all files of the bot.","content":{"application/json":{"schema":{"type":"object","properties":{"tags":{"type":"array","items":{"type":"string"}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["tags","meta"],"title":"listFileTagsResponse","additionalProperties":false}}}},"listFileTagValuesResponse":{"description":"Returns the list of available values used for a given tag across all files of the bot.","content":{"application/json":{"schema":{"type":"object","properties":{"values":{"type":"array","items":{"type":"string"}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["values","meta"],"title":"listFileTagValuesResponse","additionalProperties":false}}}},"createKnowledgeBaseResponse":{"description":"The created knowledge base","content":{"application/json":{"schema":{"type":"object","properties":{"knowledgeBase":{"type":"object","properties":{"id":{"type":"string","description":"Knowledge base ID"},"name":{"type":"string","description":"Name of the knowledge base."}},"required":["id","name"],"additionalProperties":false}},"required":["knowledgeBase"],"title":"createKnowledgeBaseResponse","additionalProperties":false}}}},"deleteKnowledgeBaseResponse":{"description":"Empty response.","content":{"application/json":{"schema":{"type":"object","title":"deleteKnowledgeBaseResponse","additionalProperties":false}}}},"updateKnowledgeBaseResponse":{"description":"The updated knowledge base","content":{"application/json":{"schema":{"type":"object","properties":{"knowledgeBase":{"type":"object","properties":{"id":{"type":"string","description":"Knowledge base ID"},"name":{"type":"string","description":"Name of the knowledge base."}},"required":["id","name"],"additionalProperties":false}},"required":["knowledgeBase"],"title":"updateKnowledgeBaseResponse","additionalProperties":false}}}},"listKnowledgeBasesResponse":{"description":"Returns the list of knowledge bases for the bot.","content":{"application/json":{"schema":{"type":"object","properties":{"knowledgeBases":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"Knowledge base ID"},"name":{"type":"string","description":"Name of the knowledge base."},"createdAt":{"type":"string","description":"Knowledge base creation timestamp in ISO 8601 format"}},"required":["id","name","createdAt"]}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["knowledgeBases","meta"],"title":"listKnowledgeBasesResponse","additionalProperties":false}}}}},"requestBodies":{"upsertFileBody":{"description":"Properties of the file to create or update.","content":{"application/json":{"schema":{"type":"object","properties":{"key":{"type":"string","description":"Unique key for the file. Must be unique across the bot (and the integration, when applicable)."},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":1000},"description":"File tags as an object of key-value pairs. Tag values should be of `string` (text) type."},"size":{"type":"number","description":"File size in bytes. This will count against your File Storage quota. If the `index` parameter is set to `true`, this will also count against your Vector DB Storage quota."},"index":{"default":false,"type":"boolean","description":"Set to a value of 'true' to index the file in vector storage. Only certain file formats are currently supported for indexing. Files larger than 95 MB cannot be indexed. Note that if a file is indexed, it will count towards both the Vector DB Storage quota and the File Storage quota of the workspace."},"indexing":{"type":"object","properties":{"configuration":{"type":"object","properties":{"parsing":{"type":"object","properties":{"minimumParagraphLength":{"type":"integer","minimum":50,"maximum":2000,"description":"The minimum length a standalone paragraph should have. If a paragraph is shorter than this, it will be merged with the next immediate paragraph."},"smartCleanup":{"type":"boolean","description":"(Team/Enterprise plan only, charged as AI Spend) Enabling this will use a lightweight/inexpensive LLM to clean up the extracted content of PDF files before indexing them to increase the quality of the stored vectors, as PDFs often store raw text in unusual ways which when extracted may result in formatting issues (e.g. broken sentences/paragraphs, unexpected headings, garbled characters, etc.) that can affect retrieval performance for certain user queries if left untouched.\n\nNotes:\n- This feature is only available in Team and Enterprise plans.\n- This feature is only available for PDF files. If the file isn't a PDF, this setting will be ignored and no AI Spend will be incurred.\n- We recommend using this feature for PDFs that have custom layouts or design. For simple text-based PDFs like documents and books, this feature is usually not necessary.\n- The smart cleanup takes some time to perform due to the LLM calls involved, so enabling it will increase the total time it takes to index the file.\n- We take steps to prevent the original text from being fundamentally changed but due to the nature of LLMs this could theoretically still happen so it's recommended to review the passages generated for the file after indexing to ensure the content is still accurate.\n- This feature is limited to the first 30 pages or 20 KB of text in the PDF file (whichever comes first). If the file has more content than these limits then the rest of the file will be indexed as-is without any cleanup. If you need to clean up the content of the entire file, consider splitting it into smaller files."}},"additionalProperties":false},"chunking":{"type":"object","properties":{"maximumChunkLength":{"type":"integer","minimum":100,"maximum":5000,"description":"The maximum length of a chunk in characters."},"embeddedContextLevels":{"type":"integer","minimum":0,"maximum":3,"description":"The number of surrounding context levels to include in the vector embedding of the chunk."},"embedBreadcrumb":{"type":"boolean","description":"Include the breadcrumb of the chunk in the vector embedding."}},"additionalProperties":false},"summarization":{"type":"object","properties":{"enable":{"default":false,"type":"boolean","description":"(Team/Enterprise plan only, charged as AI Spend) Create summaries for this file and index them as standalone vectors. Enabling this option will incur in AI Spend cost (charged to the workspace of the bot) to generate the summaries based on the amount of content in the file and the summarization model used.\n\nPlease note that this feature is only available in Team and Enterprise plans."},"modelType":{"default":"balanced","type":"string","enum":["inexpensive","balanced","accurate"],"description":"The model type to use for summarization."},"minimumInputLength":{"type":"integer","minimum":1000,"maximum":10000,"description":"The minimum length a section of the file should have to create a summary of it."},"outputTokenLimit":{"type":"integer","minimum":1000,"maximum":10000,"description":"The maximum length of a summary (in tokens)."},"generateMasterSummary":{"type":"boolean","description":"Generate a summary of the entire file and index it as a standalone vector."}},"additionalProperties":false},"stack":{"type":"string","enum":["realtime-v1"],"description":"Internal setting, cannot be set manually."},"vision":{"type":"object","properties":{"transcribePages":{"description":"(Team/Enterprise plan only, charged as AI Spend) For PDF files, set this option to `true` or pass an array with specific page numbers to use a vision-enabled LLM to transcribe each page of the PDF as standalone vectors and index them.\n\nThis feature is useful when a PDF file contains custom designs or layouts, or when your document has many infographics, which require visual processing in order to index the file effectively, as the default text-based indexing may not be enough to allow your bot to correctly understand the content in your PDFs.\n\nNotes:\n- This feature is only available in Team and Enterprise plans.\n- Enabling this feature will incur in AI Spend cost to use a vision-enabled LLM to index the PDF pages.\n- This is limited to a maximum of 100 pages of the PDF. If the file has more pages then the rest of the pages will NOT be transcribed using this vision feature, and will be processed using the default text-based indexing instead. If you need to transcribe the entire file using vision, please split it into smaller files.\n- Pages that are vision-transcribed will not be processed by the default text-based indexing to avoid duplicate content in the index.\n- This feature is only available for PDF files. If the file isn't a PDF, this setting will be ignored and no AI Spend will be incurred."},"indexPages":{"description":"(Team/Enterprise plan only, charged as AI Spend) For PDF files, set this option to `true` or pass an array with specific page numbers to use a vision-enabled LLM to index each page of the PDF as a standalone image.\n\nEnabling this feature will allow Autonomous Nodes in your bot to answer visual or higher-level questions about the content in these pages that can usually not be answered correctly by the default text-based indexing or visual transcription.\n\nThis feature is useful when a PDF has:\n- Tables with complex layouts\n- Charts, diagrams or infographics\n- Photos or images that can be used to answer user queries\n\nNotes:\n- This feature is only available in Team and Enterprise plans.\n- Enabling this will incur in extra AI Spend cost and additional File Storage usage, in order to use a vision-enabled LLM to visually index the PDF pages and store them as standalone page images in the bot's file storage.\n- Enabling this may increase the overall AI Spend cost of your bot as your bot may pass one or more indexed page images to a vision-enabled LLM for answering user queries.\n- This is limited to the first 100 pages of the PDF. If the file has more pages then the rest of the pages will NOT be vision-indexed. If you need to visually index the entire file, please split it into smaller files.\n- This feature is only available for PDF files. If the file isn't a PDF, this setting will be ignored and no AI Spend will be incurred."}},"additionalProperties":false}},"description":"Configuration to use for indexing the file, will be stored in the file's metadata for reference.","additionalProperties":false}},"required":["configuration"],"additionalProperties":false},"accessPolicies":{"type":"array","items":{"type":"string","enum":["public_content","integrations"]},"description":"File access policies. Add \"public_content\" to allow public access to the file content. Add \"integrations\" to allow read, search and list operations for any integration installed in the bot."},"contentType":{"type":"string","description":"File content type. If omitted, the content type will be inferred from the file extension (if any) specified in `key`. If a content type cannot be inferred, the default is \"application/octet-stream\"."},"expiresAt":{"type":"string","format":"date-time","description":"Expiry timestamp in ISO 8601 format with UTC timezone. After expiry, the File will be deleted. Must be in the future. Cannot be more than 90 days from now. The value up to minutes is considered. Seconds and milliseconds are ignored."},"publicContentImmediatelyAccessible":{"type":"boolean","description":"Use when your file has \"public_content\" in its access policy and you need the file\\'s content to be immediately accessible through its URL after the file has been uploaded without having to wait for the upload to be processed by our system.\n\nIf set to `true`, the `x-amz-tagging` HTTP header with a value of `public=true` will need to be sent in the HTTP PUT request to the `uploadUrl` in order for the upload request to work."},"metadata":{"description":"Custom metadata for the file expressed as an object of key-value pairs. The values can be of any type."}},"required":["key","size"],"title":"upsertFileBody","additionalProperties":false}}}},"updateFileMetadataBody":{"description":"File metadata to update.","content":{"application/json":{"schema":{"type":"object","properties":{"metadata":{"description":"Custom metadata for the file expressed as an object of key-value pairs. Omit to keep existing metadata intact. Any existing metadata keys not included will be preserved. New keys will be added. To delete a metadata key, set its value to `null`."},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":1000,"nullable":true},"description":"The file tags to update as an object of key-value pairs with `string` (text) values. Omit to keep existing tags intact. Any existing tags not included will be preserved. New tags will be added. To delete a tag, set its value to `null`."},"accessPolicies":{"type":"array","items":{"type":"string","enum":["integrations","public_content"]},"description":"New access policies to set for the file. Omit to keep existing policies intact."},"expiresAt":{"type":"string","format":"date-time","description":"Expiry timestamp in ISO 8601 format with UTC timezone. After expiry, the File will be deleted. Must be in the future. Cannot be more than 90 days from now. The value up to minutes is considered. Seconds and milliseconds are ignored. Omit to keep the existing expiry intact. Set to `null` to remove the expiry.","nullable":true}},"title":"updateFileMetadataBody","additionalProperties":false}}}},"copyFileBody":{"description":"Additional options for file copying.","content":{"application/json":{"schema":{"type":"object","properties":{"overwrite":{"type":"boolean","description":"Set to `true` to overwrite the file if it already exists, otherwise an error will be returned.\n\nWhen this endpoint is called using bot authentication, the existing file must have been originally created by the same bot making the file copy request in order to overwrite it."}},"title":"copyFileBody","additionalProperties":false}}}},"setFilePassagesBody":{"description":"List of passages to index for the file. These will replacing all the existing passages. Indexing of the new passages will be done asynchronously in the background. You can check the file status to see when the indexing is complete.","content":{"application/json":{"schema":{"type":"object","properties":{"passages":{"type":"array","items":{"type":"object","properties":{"content":{"type":"string","description":"The content of the passage, supports Markdown formatting."},"type":{"default":"paragraph","type":"string","enum":["title","subtitle","paragraph","blockquote","list","table","code","image"],"description":"The type should match the Markdown format used for the passage content."},"pageNumber":{"type":"integer"}},"required":["content"]},"description":"Note: The passages should appear in the array in the same order as they appear in the original document."}},"required":["passages"],"title":"setFilePassagesBody","additionalProperties":false}}}},"createKnowledgeBaseBody":{"description":"Properties of the knowledge base.","content":{"application/json":{"schema":{"type":"object","properties":{"name":{"type":"string","description":"Name of the knowledge base."}},"required":["name"],"title":"createKnowledgeBaseBody","additionalProperties":false}}}},"updateKnowledgeBaseBody":{"description":"Properties of the knowledge base to update.","content":{"application/json":{"schema":{"type":"object","properties":{"name":{"type":"string","description":"New name of the knowledge base."}},"required":["name"],"title":"updateKnowledgeBaseBody","additionalProperties":false}}}}},"parameters":{}}}
+{
+    "openapi": "3.0.0",
+    "servers": [
+        {
+            "url": "https://api.botpress.cloud"
+        }
+    ],
+    "info": {
+        "title": "Botpress Files API",
+        "description": "API for Files",
+        "version": "0.18.0"
+    },
+    "paths": {
+        "/v1/files": {
+            "put": {
+                "operationId": "upsertFile",
+                "description": "Creates or updates a file using the `key` parameter as unique identifier. Updating a file will erase the existing content of the file. Upload the file content by sending it in a PUT request to the `uploadUrl` returned in the response.",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/upsertFileResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/upsertFileResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/upsertFileBody"
+                }
+            },
+            "get": {
+                "operationId": "listFiles",
+                "description": "List files for bot",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sortField",
+                        "in": "query",
+                        "description": "Sort results by this field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "key",
+                                "size",
+                                "createdAt",
+                                "updatedAt",
+                                "status"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "sortDirection",
+                        "in": "query",
+                        "description": "Sort results in this direction",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Filter files by tags. Tags should be passed as a URL-encoded JSON object of key-value pairs that must be present in the tags of a file. An array of multiple string values for the same key are treated as an OR condition. To exclude a value, express it as an object with a nested `not` key with the string or string-array value(s) to exclude.",
+                        "schema": {}
+                    },
+                    {
+                        "name": "ids",
+                        "in": "query",
+                        "description": "Filter files by IDs.",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "maxItems": 50
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listFilesResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listFilesResponse"
+                    }
+                }
+            }
+        },
+        "/v1/files/{id}": {
+            "delete": {
+                "operationId": "deleteFile",
+                "description": "Deletes a file.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "File ID or Key",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/deleteFileResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/deleteFileResponse"
+                    }
+                }
+            },
+            "get": {
+                "operationId": "getFile",
+                "description": "Get file",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "File ID or Key",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getFileResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getFileResponse"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "updateFileMetadata",
+                "description": "Update file metadata, without updating the file content.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "File ID or Key",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/updateFileMetadataResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/updateFileMetadataResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/updateFileMetadataBody"
+                }
+            }
+        },
+        "/v1/files/{idOrKey}/{destinationKey}": {
+            "post": {
+                "operationId": "copyFile",
+                "description": "Copy file",
+                "parameters": [
+                    {
+                        "name": "idOrKey",
+                        "in": "path",
+                        "description": "File ID or Key",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "destinationKey",
+                        "in": "path",
+                        "description": "The new key of the file. The file key must not be in use already in the destination bot.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "x-destination-bot-id",
+                        "in": "header",
+                        "description": "The bot ID to copy the file to. You must have permission to create files in the destination bot. If the destination bot ID is omitted, the file will be copied to the same bot the source file belongs to.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/copyFileResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/copyFileResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/copyFileBody"
+                }
+            }
+        },
+        "/v1/files/search": {
+            "get": {
+                "operationId": "searchFiles",
+                "description": "Search files",
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Filter files by tags. Tags should be passed as a URL-encoded JSON object of key-value pairs that must be present in the tags of a file. An array of multiple string values for the same key are treated as an OR condition. To exclude a value, express it as an object with a nested `not` key with the string or string-array value(s) to exclude.",
+                        "schema": {}
+                    },
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "description": "Query expressed in natural language to retrieve matching text passages within all indexed files in the bot using semantical search.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "contextDepth",
+                        "in": "query",
+                        "description": "The number of neighbor passages to prepend and append as surrounding context to the content of each returned passage (default: 1, minimum: 0, maximum: 10).",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of passages to return.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "consolidate",
+                        "in": "query",
+                        "description": "Consolidate the results by merging matching passages from the same file into a single passage per file. The consolidated passage will include the matching passages ordered by their original position in the file (rather than by relevance score) and include hierarchical context such as the title/subtitle to which they belong.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "name": "includeBreadcrumb",
+                        "in": "query",
+                        "description": "Prepend a breadcrumb to each passage, containing the title and subtitle(s) the passage belongs to in the file. This option is ignored when the `consolidate` option is set to `true`.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/searchFilesResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/searchFilesResponse"
+                    }
+                }
+            }
+        },
+        "/v1/files/{id}/passages": {
+            "get": {
+                "operationId": "listFilePassages",
+                "description": "List passages for a file",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "File ID or Key",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of passages to return per request (optional, default: 20, max: 200).",
+                        "schema": {
+                            "type": "number"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listFilePassagesResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listFilePassagesResponse"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "setFilePassages",
+                "description": "Sets the indexed file passages asynchronously. All existing indexed passages will be deleted as soon as the indexing begins. This endpoint will return immediately and set the file status to \"indexing_pending\". Once the new passages are indexed the file status will be set to \"indexing_completed\", or \"indexing_failed\" if the passages failed to be indexed.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "File ID or Key",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/setFilePassagesResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/setFilePassagesResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/setFilePassagesBody"
+                }
+            }
+        },
+        "/v1/files/tags": {
+            "get": {
+                "operationId": "listFileTags",
+                "description": "List available tags",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listFileTagsResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listFileTagsResponse"
+                    }
+                }
+            }
+        },
+        "/v1/files/tags/{tag}/values": {
+            "get": {
+                "operationId": "listFileTagValues",
+                "description": "List available tags",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tag",
+                        "in": "path",
+                        "description": "Tag name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listFileTagValuesResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listFileTagValuesResponse"
+                    }
+                }
+            }
+        },
+        "/v1/files/knowledge-bases": {
+            "post": {
+                "operationId": "createKnowledgeBase",
+                "description": "Creates a knowledge base for grouping files.",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/createKnowledgeBaseResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/createKnowledgeBaseResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/createKnowledgeBaseBody"
+                }
+            },
+            "get": {
+                "operationId": "listKnowledgeBases",
+                "description": "List knowledge bases for bot",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listKnowledgeBasesResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listKnowledgeBasesResponse"
+                    }
+                }
+            }
+        },
+        "/v1/files/knowledge-bases/{id}": {
+            "delete": {
+                "operationId": "deleteKnowledgeBase",
+                "description": "Deletes a knowledge base.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Knowledge base ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/deleteKnowledgeBaseResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/deleteKnowledgeBaseResponse"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "updateKnowledgeBase",
+                "description": "Updates a knowledge base.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Knowledge base ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/updateKnowledgeBaseResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/updateKnowledgeBaseResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/updateKnowledgeBaseBody"
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "File": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "File ID"
+                    },
+                    "botId": {
+                        "type": "string",
+                        "description": "The ID of the bot the file belongs to"
+                    },
+                    "key": {
+                        "type": "string",
+                        "description": "Unique key for the file. Must be unique across the bot (and the integration, when applicable)."
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."
+                    },
+                    "size": {
+                        "type": "number",
+                        "description": "File size in bytes. Non-null if file upload status is \"COMPLETE\".",
+                        "nullable": true
+                    },
+                    "contentType": {
+                        "type": "string",
+                        "description": "MIME type of the file's content"
+                    },
+                    "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "maxLength": 1000
+                        },
+                        "description": "The tags of the file as an object of key/value pairs"
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "nullable": true
+                        },
+                        "description": "Metadata of the file as an object of key/value pairs. The values can be of any type."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "description": "File creation timestamp in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "description": "File last update timestamp in ISO 8601 format"
+                    },
+                    "accessPolicies": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "integrations",
+                                "public_content"
+                            ]
+                        },
+                        "description": "Access policies configured for the file."
+                    },
+                    "index": {
+                        "type": "boolean",
+                        "description": "Whether the file was requested to be indexed for search or not."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "upload_pending",
+                            "upload_failed",
+                            "upload_completed",
+                            "indexing_pending",
+                            "indexing_failed",
+                            "indexing_completed"
+                        ],
+                        "description": "Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."
+                    },
+                    "failedStatusReason": {
+                        "type": "string",
+                        "description": "If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."
+                    },
+                    "expiresAt": {
+                        "type": "string",
+                        "description": "File expiry timestamp in ISO 8601 format"
+                    },
+                    "owner": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "bot",
+                                    "integration",
+                                    "user"
+                                ]
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                "required": [
+                    "id",
+                    "botId",
+                    "key",
+                    "url",
+                    "size",
+                    "contentType",
+                    "tags",
+                    "metadata",
+                    "createdAt",
+                    "updatedAt",
+                    "accessPolicies",
+                    "index",
+                    "status",
+                    "owner"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "responses": {
+            "upsertFileResponse": {
+                "description": "The created or updated file",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "file": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "File ID"
+                                        },
+                                        "botId": {
+                                            "type": "string",
+                                            "description": "The ID of the bot the file belongs to"
+                                        },
+                                        "key": {
+                                            "type": "string",
+                                            "description": "Unique key for the file. Must be unique across the bot (and the integration, when applicable)."
+                                        },
+                                        "url": {
+                                            "type": "string",
+                                            "description": "URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."
+                                        },
+                                        "size": {
+                                            "type": "number",
+                                            "description": "File size in bytes. Non-null if file upload status is \"COMPLETE\".",
+                                            "nullable": true
+                                        },
+                                        "contentType": {
+                                            "type": "string",
+                                            "description": "MIME type of the file's content"
+                                        },
+                                        "tags": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "string",
+                                                "maxLength": 1000
+                                            },
+                                            "description": "The tags of the file as an object of key/value pairs"
+                                        },
+                                        "metadata": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "nullable": true
+                                            },
+                                            "description": "Metadata of the file as an object of key/value pairs. The values can be of any type."
+                                        },
+                                        "createdAt": {
+                                            "type": "string",
+                                            "description": "File creation timestamp in ISO 8601 format"
+                                        },
+                                        "updatedAt": {
+                                            "type": "string",
+                                            "description": "File last update timestamp in ISO 8601 format"
+                                        },
+                                        "accessPolicies": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "integrations",
+                                                    "public_content"
+                                                ]
+                                            },
+                                            "description": "Access policies configured for the file."
+                                        },
+                                        "index": {
+                                            "type": "boolean",
+                                            "description": "Whether the file was requested to be indexed for search or not."
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "upload_pending",
+                                                "upload_failed",
+                                                "upload_completed",
+                                                "indexing_pending",
+                                                "indexing_failed",
+                                                "indexing_completed"
+                                            ],
+                                            "description": "Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."
+                                        },
+                                        "failedStatusReason": {
+                                            "type": "string",
+                                            "description": "If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."
+                                        },
+                                        "expiresAt": {
+                                            "type": "string",
+                                            "description": "File expiry timestamp in ISO 8601 format"
+                                        },
+                                        "owner": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "bot",
+                                                        "integration",
+                                                        "user"
+                                                    ]
+                                                },
+                                                "id": {
+                                                    "type": "string",
+                                                    "description": "This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ],
+                                            "additionalProperties": false
+                                        },
+                                        "uploadUrl": {
+                                            "type": "string",
+                                            "description": "URL to upload the file content. File content needs to be sent to this URL via a PUT request."
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "botId",
+                                        "key",
+                                        "url",
+                                        "size",
+                                        "contentType",
+                                        "tags",
+                                        "metadata",
+                                        "createdAt",
+                                        "updatedAt",
+                                        "accessPolicies",
+                                        "index",
+                                        "status",
+                                        "owner",
+                                        "uploadUrl"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "file"
+                            ],
+                            "title": "upsertFileResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "deleteFileResponse": {
+                "description": "Empty response.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "deleteFileResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listFilesResponse": {
+                "description": "Returns the list of files related to the bot.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "files": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "File ID"
+                                            },
+                                            "botId": {
+                                                "type": "string",
+                                                "description": "The ID of the bot the file belongs to"
+                                            },
+                                            "key": {
+                                                "type": "string",
+                                                "description": "Unique key for the file. Must be unique across the bot (and the integration, when applicable)."
+                                            },
+                                            "url": {
+                                                "type": "string",
+                                                "description": "URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."
+                                            },
+                                            "size": {
+                                                "type": "number",
+                                                "description": "File size in bytes. Non-null if file upload status is \"COMPLETE\".",
+                                                "nullable": true
+                                            },
+                                            "contentType": {
+                                                "type": "string",
+                                                "description": "MIME type of the file's content"
+                                            },
+                                            "tags": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string",
+                                                    "maxLength": 1000
+                                                },
+                                                "description": "The tags of the file as an object of key/value pairs"
+                                            },
+                                            "metadata": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "nullable": true
+                                                },
+                                                "description": "Metadata of the file as an object of key/value pairs. The values can be of any type."
+                                            },
+                                            "createdAt": {
+                                                "type": "string",
+                                                "description": "File creation timestamp in ISO 8601 format"
+                                            },
+                                            "updatedAt": {
+                                                "type": "string",
+                                                "description": "File last update timestamp in ISO 8601 format"
+                                            },
+                                            "accessPolicies": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "integrations",
+                                                        "public_content"
+                                                    ]
+                                                },
+                                                "description": "Access policies configured for the file."
+                                            },
+                                            "index": {
+                                                "type": "boolean",
+                                                "description": "Whether the file was requested to be indexed for search or not."
+                                            },
+                                            "status": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "upload_pending",
+                                                    "upload_failed",
+                                                    "upload_completed",
+                                                    "indexing_pending",
+                                                    "indexing_failed",
+                                                    "indexing_completed"
+                                                ],
+                                                "description": "Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."
+                                            },
+                                            "failedStatusReason": {
+                                                "type": "string",
+                                                "description": "If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."
+                                            },
+                                            "expiresAt": {
+                                                "type": "string",
+                                                "description": "File expiry timestamp in ISO 8601 format"
+                                            },
+                                            "owner": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "bot",
+                                                            "integration",
+                                                            "user"
+                                                        ]
+                                                    },
+                                                    "id": {
+                                                        "type": "string",
+                                                        "description": "This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "botId",
+                                            "key",
+                                            "url",
+                                            "size",
+                                            "contentType",
+                                            "tags",
+                                            "metadata",
+                                            "createdAt",
+                                            "updatedAt",
+                                            "accessPolicies",
+                                            "index",
+                                            "status",
+                                            "owner"
+                                        ]
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "files",
+                                "meta"
+                            ],
+                            "title": "listFilesResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getFileResponse": {
+                "description": "An object containing the file metadata and URL",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "file": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "File ID"
+                                        },
+                                        "botId": {
+                                            "type": "string",
+                                            "description": "The ID of the bot the file belongs to"
+                                        },
+                                        "key": {
+                                            "type": "string",
+                                            "description": "Unique key for the file. Must be unique across the bot (and the integration, when applicable)."
+                                        },
+                                        "url": {
+                                            "type": "string",
+                                            "description": "URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."
+                                        },
+                                        "size": {
+                                            "type": "number",
+                                            "description": "File size in bytes. Non-null if file upload status is \"COMPLETE\".",
+                                            "nullable": true
+                                        },
+                                        "contentType": {
+                                            "type": "string",
+                                            "description": "MIME type of the file's content"
+                                        },
+                                        "tags": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "string",
+                                                "maxLength": 1000
+                                            },
+                                            "description": "The tags of the file as an object of key/value pairs"
+                                        },
+                                        "metadata": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "nullable": true
+                                            },
+                                            "description": "Metadata of the file as an object of key/value pairs. The values can be of any type."
+                                        },
+                                        "createdAt": {
+                                            "type": "string",
+                                            "description": "File creation timestamp in ISO 8601 format"
+                                        },
+                                        "updatedAt": {
+                                            "type": "string",
+                                            "description": "File last update timestamp in ISO 8601 format"
+                                        },
+                                        "accessPolicies": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "integrations",
+                                                    "public_content"
+                                                ]
+                                            },
+                                            "description": "Access policies configured for the file."
+                                        },
+                                        "index": {
+                                            "type": "boolean",
+                                            "description": "Whether the file was requested to be indexed for search or not."
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "upload_pending",
+                                                "upload_failed",
+                                                "upload_completed",
+                                                "indexing_pending",
+                                                "indexing_failed",
+                                                "indexing_completed"
+                                            ],
+                                            "description": "Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."
+                                        },
+                                        "failedStatusReason": {
+                                            "type": "string",
+                                            "description": "If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."
+                                        },
+                                        "expiresAt": {
+                                            "type": "string",
+                                            "description": "File expiry timestamp in ISO 8601 format"
+                                        },
+                                        "owner": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "bot",
+                                                        "integration",
+                                                        "user"
+                                                    ]
+                                                },
+                                                "id": {
+                                                    "type": "string",
+                                                    "description": "This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "botId",
+                                        "key",
+                                        "url",
+                                        "size",
+                                        "contentType",
+                                        "tags",
+                                        "metadata",
+                                        "createdAt",
+                                        "updatedAt",
+                                        "accessPolicies",
+                                        "index",
+                                        "status",
+                                        "owner"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "file"
+                            ],
+                            "title": "getFileResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateFileMetadataResponse": {
+                "description": "An object containing the updated file metadata.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "file": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "File ID"
+                                        },
+                                        "botId": {
+                                            "type": "string",
+                                            "description": "The ID of the bot the file belongs to"
+                                        },
+                                        "key": {
+                                            "type": "string",
+                                            "description": "Unique key for the file. Must be unique across the bot (and the integration, when applicable)."
+                                        },
+                                        "url": {
+                                            "type": "string",
+                                            "description": "URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."
+                                        },
+                                        "size": {
+                                            "type": "number",
+                                            "description": "File size in bytes. Non-null if file upload status is \"COMPLETE\".",
+                                            "nullable": true
+                                        },
+                                        "contentType": {
+                                            "type": "string",
+                                            "description": "MIME type of the file's content"
+                                        },
+                                        "tags": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "string",
+                                                "maxLength": 1000
+                                            },
+                                            "description": "The tags of the file as an object of key/value pairs"
+                                        },
+                                        "metadata": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "nullable": true
+                                            },
+                                            "description": "Metadata of the file as an object of key/value pairs. The values can be of any type."
+                                        },
+                                        "createdAt": {
+                                            "type": "string",
+                                            "description": "File creation timestamp in ISO 8601 format"
+                                        },
+                                        "updatedAt": {
+                                            "type": "string",
+                                            "description": "File last update timestamp in ISO 8601 format"
+                                        },
+                                        "accessPolicies": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "integrations",
+                                                    "public_content"
+                                                ]
+                                            },
+                                            "description": "Access policies configured for the file."
+                                        },
+                                        "index": {
+                                            "type": "boolean",
+                                            "description": "Whether the file was requested to be indexed for search or not."
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "upload_pending",
+                                                "upload_failed",
+                                                "upload_completed",
+                                                "indexing_pending",
+                                                "indexing_failed",
+                                                "indexing_completed"
+                                            ],
+                                            "description": "Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."
+                                        },
+                                        "failedStatusReason": {
+                                            "type": "string",
+                                            "description": "If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."
+                                        },
+                                        "expiresAt": {
+                                            "type": "string",
+                                            "description": "File expiry timestamp in ISO 8601 format"
+                                        },
+                                        "owner": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "bot",
+                                                        "integration",
+                                                        "user"
+                                                    ]
+                                                },
+                                                "id": {
+                                                    "type": "string",
+                                                    "description": "This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "botId",
+                                        "key",
+                                        "url",
+                                        "size",
+                                        "contentType",
+                                        "tags",
+                                        "metadata",
+                                        "createdAt",
+                                        "updatedAt",
+                                        "accessPolicies",
+                                        "index",
+                                        "status",
+                                        "owner"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "file"
+                            ],
+                            "title": "updateFileMetadataResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "copyFileResponse": {
+                "description": "An object containing the file metadata and URL",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "file": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "File ID"
+                                        },
+                                        "botId": {
+                                            "type": "string",
+                                            "description": "The ID of the bot the file belongs to"
+                                        },
+                                        "key": {
+                                            "type": "string",
+                                            "description": "Unique key for the file. Must be unique across the bot (and the integration, when applicable)."
+                                        },
+                                        "url": {
+                                            "type": "string",
+                                            "description": "URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."
+                                        },
+                                        "size": {
+                                            "type": "number",
+                                            "description": "File size in bytes. Non-null if file upload status is \"COMPLETE\".",
+                                            "nullable": true
+                                        },
+                                        "contentType": {
+                                            "type": "string",
+                                            "description": "MIME type of the file's content"
+                                        },
+                                        "tags": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "string",
+                                                "maxLength": 1000
+                                            },
+                                            "description": "The tags of the file as an object of key/value pairs"
+                                        },
+                                        "metadata": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "nullable": true
+                                            },
+                                            "description": "Metadata of the file as an object of key/value pairs. The values can be of any type."
+                                        },
+                                        "createdAt": {
+                                            "type": "string",
+                                            "description": "File creation timestamp in ISO 8601 format"
+                                        },
+                                        "updatedAt": {
+                                            "type": "string",
+                                            "description": "File last update timestamp in ISO 8601 format"
+                                        },
+                                        "accessPolicies": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "integrations",
+                                                    "public_content"
+                                                ]
+                                            },
+                                            "description": "Access policies configured for the file."
+                                        },
+                                        "index": {
+                                            "type": "boolean",
+                                            "description": "Whether the file was requested to be indexed for search or not."
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "upload_pending",
+                                                "upload_failed",
+                                                "upload_completed",
+                                                "indexing_pending",
+                                                "indexing_failed",
+                                                "indexing_completed"
+                                            ],
+                                            "description": "Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."
+                                        },
+                                        "failedStatusReason": {
+                                            "type": "string",
+                                            "description": "If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."
+                                        },
+                                        "expiresAt": {
+                                            "type": "string",
+                                            "description": "File expiry timestamp in ISO 8601 format"
+                                        },
+                                        "owner": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "bot",
+                                                        "integration",
+                                                        "user"
+                                                    ]
+                                                },
+                                                "id": {
+                                                    "type": "string",
+                                                    "description": "This field is present if `type` is \"user\" or \"bot\". If `type` is \"user\", this is the user ID. If `type` is \"bot\", this is the bot ID."
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "This field is present if the `type` is \"integration\". If `type` is \"integration\", this is the integration name."
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "botId",
+                                        "key",
+                                        "url",
+                                        "size",
+                                        "contentType",
+                                        "tags",
+                                        "metadata",
+                                        "createdAt",
+                                        "updatedAt",
+                                        "accessPolicies",
+                                        "index",
+                                        "status",
+                                        "owner"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "file"
+                            ],
+                            "title": "copyFileResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "searchFilesResponse": {
+                "description": "Returns the text passages within all indexed files that matched the query.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "passages": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "content": {
+                                                "type": "string",
+                                                "description": "The content of the matching passage in the file including surrounding context, if any."
+                                            },
+                                            "score": {
+                                                "type": "number",
+                                                "description": "The score indicating the similarity of the passage to the query. A higher score indicates higher similarity."
+                                            },
+                                            "meta": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "chunk",
+                                                            "summary",
+                                                            "consolidated",
+                                                            "image"
+                                                        ],
+                                                        "description": "The type of passage"
+                                                    },
+                                                    "subtype": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "title",
+                                                            "subtitle",
+                                                            "paragraph",
+                                                            "blockquote",
+                                                            "list",
+                                                            "table",
+                                                            "code",
+                                                            "image",
+                                                            "page"
+                                                        ],
+                                                        "description": "The subtype of passage, if available."
+                                                    },
+                                                    "pageNumber": {
+                                                        "type": "integer",
+                                                        "description": "Page number the passage is located on. Only applicable if the passage was extracted from a PDF file."
+                                                    },
+                                                    "position": {
+                                                        "type": "integer",
+                                                        "description": "Position number of the passage in the file relative to the other passages, if available. Can be used to know the order of passages within a file."
+                                                    },
+                                                    "sourceUrl": {
+                                                        "type": "string",
+                                                        "format": "uri",
+                                                        "description": "The URL of the source file for the vector, if applicable (e.g. for image vectors)."
+                                                    }
+                                                },
+                                                "description": "The passage metadata."
+                                            },
+                                            "file": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string",
+                                                        "description": "File ID"
+                                                    },
+                                                    "key": {
+                                                        "type": "string",
+                                                        "description": "Unique key for the file. Must be unique across the bot (and the integration, when applicable)."
+                                                    },
+                                                    "contentType": {
+                                                        "type": "string",
+                                                        "description": "MIME type of the file's content"
+                                                    },
+                                                    "tags": {
+                                                        "type": "object",
+                                                        "additionalProperties": {
+                                                            "type": "string",
+                                                            "maxLength": 1000
+                                                        },
+                                                        "description": "The tags of the file as an object of key-value pairs."
+                                                    },
+                                                    "createdAt": {
+                                                        "type": "string",
+                                                        "description": "File creation timestamp in ISO 8601 format"
+                                                    },
+                                                    "updatedAt": {
+                                                        "type": "string",
+                                                        "description": "File last update timestamp in ISO 8601 format"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "id",
+                                                    "key",
+                                                    "contentType",
+                                                    "tags",
+                                                    "createdAt",
+                                                    "updatedAt"
+                                                ]
+                                            },
+                                            "context": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "string",
+                                                            "format": "uuid"
+                                                        },
+                                                        "text": {
+                                                            "type": "string"
+                                                        },
+                                                        "offset": {
+                                                            "type": "integer",
+                                                            "description": "Position of the context passage relative to the current passage. Negative for preceding passages, positive for subsequent, ommited for breadcrumbs."
+                                                        },
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "preceding",
+                                                                "subsequent",
+                                                                "breadcrumb"
+                                                            ],
+                                                            "description": "The type of context passage"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id",
+                                                        "text",
+                                                        "type"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "content",
+                                            "score",
+                                            "meta",
+                                            "file"
+                                        ]
+                                    }
+                                }
+                            },
+                            "required": [
+                                "passages"
+                            ],
+                            "title": "searchFilesResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listFilePassagesResponse": {
+                "description": "Returns the list of passages extracted from a file.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "passages": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "Passage ID"
+                                            },
+                                            "content": {
+                                                "type": "string",
+                                                "description": "The content of the passage."
+                                            },
+                                            "meta": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "chunk",
+                                                            "summary",
+                                                            "consolidated",
+                                                            "image"
+                                                        ],
+                                                        "description": "The type of passage"
+                                                    },
+                                                    "subtype": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "title",
+                                                            "subtitle",
+                                                            "paragraph",
+                                                            "blockquote",
+                                                            "list",
+                                                            "table",
+                                                            "code",
+                                                            "image",
+                                                            "page"
+                                                        ],
+                                                        "description": "The subtype of passage, if available."
+                                                    },
+                                                    "pageNumber": {
+                                                        "type": "integer",
+                                                        "description": "Page number the passage is located on. Only applicable if the passage was extracted from a PDF file."
+                                                    },
+                                                    "position": {
+                                                        "type": "integer",
+                                                        "description": "Position number of the passage in the file relative to the other passages, if available. Can be used to know the order of passages within a file."
+                                                    },
+                                                    "sourceUrl": {
+                                                        "type": "string",
+                                                        "format": "uri",
+                                                        "description": "The URL of the source file for the vector, if applicable (e.g. for image vectors)."
+                                                    }
+                                                },
+                                                "description": "The passage metadata."
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "content",
+                                            "meta"
+                                        ]
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "passages",
+                                "meta"
+                            ],
+                            "title": "listFilePassagesResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "setFilePassagesResponse": {
+                "description": "Empty response.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "setFilePassagesResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listFileTagsResponse": {
+                "description": "Returns the list of available tags used across all files of the bot.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "tags": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "tags",
+                                "meta"
+                            ],
+                            "title": "listFileTagsResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listFileTagValuesResponse": {
+                "description": "Returns the list of available values used for a given tag across all files of the bot.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "values": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "values",
+                                "meta"
+                            ],
+                            "title": "listFileTagValuesResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createKnowledgeBaseResponse": {
+                "description": "The created knowledge base",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "knowledgeBase": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "Knowledge base ID"
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "description": "Name of the knowledge base."
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "name"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "knowledgeBase"
+                            ],
+                            "title": "createKnowledgeBaseResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "deleteKnowledgeBaseResponse": {
+                "description": "Empty response.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "deleteKnowledgeBaseResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateKnowledgeBaseResponse": {
+                "description": "The updated knowledge base",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "knowledgeBase": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "Knowledge base ID"
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "description": "Name of the knowledge base."
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "name"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "knowledgeBase"
+                            ],
+                            "title": "updateKnowledgeBaseResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listKnowledgeBasesResponse": {
+                "description": "Returns the list of knowledge bases for the bot.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "knowledgeBases": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "Knowledge base ID"
+                                            },
+                                            "name": {
+                                                "type": "string",
+                                                "description": "Name of the knowledge base."
+                                            },
+                                            "createdAt": {
+                                                "type": "string",
+                                                "description": "Knowledge base creation timestamp in ISO 8601 format"
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "name",
+                                            "createdAt"
+                                        ]
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "knowledgeBases",
+                                "meta"
+                            ],
+                            "title": "listKnowledgeBasesResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+        },
+        "requestBodies": {
+            "upsertFileBody": {
+                "description": "Properties of the file to create or update.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "key": {
+                                    "type": "string",
+                                    "description": "Unique key for the file. Must be unique across the bot (and the integration, when applicable)."
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 1000
+                                    },
+                                    "description": "File tags as an object of key-value pairs. Tag values should be of `string` (text) type."
+                                },
+                                "size": {
+                                    "type": "number",
+                                    "description": "File size in bytes. This will count against your File Storage quota. If the `index` parameter is set to `true`, this will also count against your Vector DB Storage quota."
+                                },
+                                "index": {
+                                    "default": false,
+                                    "type": "boolean",
+                                    "description": "Set to a value of 'true' to index the file in vector storage. Only certain file formats are currently supported for indexing. Files larger than 95 MB cannot be indexed. Note that if a file is indexed, it will count towards both the Vector DB Storage quota and the File Storage quota of the workspace."
+                                },
+                                "indexing": {
+                                    "type": "object",
+                                    "properties": {
+                                        "configuration": {
+                                            "type": "object",
+                                            "properties": {
+                                                "parsing": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "minimumParagraphLength": {
+                                                            "type": "integer",
+                                                            "minimum": 50,
+                                                            "maximum": 2000,
+                                                            "description": "The minimum length a standalone paragraph should have. If a paragraph is shorter than this, it will be merged with the next immediate paragraph."
+                                                        },
+                                                        "smartCleanup": {
+                                                            "type": "boolean",
+                                                            "description": "(Team/Enterprise plan only, charged as AI Spend) Enabling this will use a lightweight/inexpensive LLM to clean up the extracted content of PDF files before indexing them to increase the quality of the stored vectors, as PDFs often store raw text in unusual ways which when extracted may result in formatting issues (e.g. broken sentences/paragraphs, unexpected headings, garbled characters, etc.) that can affect retrieval performance for certain user queries if left untouched.\n\nNotes:\n- This feature is only available in Team and Enterprise plans.\n- This feature is only available for PDF files. If the file isn't a PDF, this setting will be ignored and no AI Spend will be incurred.\n- We recommend using this feature for PDFs that have custom layouts or design. For simple text-based PDFs like documents and books, this feature is usually not necessary.\n- The smart cleanup takes some time to perform due to the LLM calls involved, so enabling it will increase the total time it takes to index the file.\n- We take steps to prevent the original text from being fundamentally changed but due to the nature of LLMs this could theoretically still happen so it's recommended to review the passages generated for the file after indexing to ensure the content is still accurate.\n- This feature is limited to the first 30 pages or 20 KB of text in the PDF file (whichever comes first). If the file has more content than these limits then the rest of the file will be indexed as-is without any cleanup. If you need to clean up the content of the entire file, consider splitting it into smaller files."
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "chunking": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "maximumChunkLength": {
+                                                            "type": "integer",
+                                                            "minimum": 100,
+                                                            "maximum": 5000,
+                                                            "description": "The maximum length of a chunk in characters."
+                                                        },
+                                                        "embeddedContextLevels": {
+                                                            "type": "integer",
+                                                            "minimum": 0,
+                                                            "maximum": 3,
+                                                            "description": "The number of surrounding context levels to include in the vector embedding of the chunk."
+                                                        },
+                                                        "embedBreadcrumb": {
+                                                            "type": "boolean",
+                                                            "description": "Include the breadcrumb of the chunk in the vector embedding."
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "summarization": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "enable": {
+                                                            "default": false,
+                                                            "type": "boolean",
+                                                            "description": "(Team/Enterprise plan only, charged as AI Spend) Create summaries for this file and index them as standalone vectors. Enabling this option will incur in AI Spend cost (charged to the workspace of the bot) to generate the summaries based on the amount of content in the file and the summarization model used.\n\nPlease note that this feature is only available in Team and Enterprise plans."
+                                                        },
+                                                        "modelType": {
+                                                            "default": "balanced",
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "inexpensive",
+                                                                "balanced",
+                                                                "accurate"
+                                                            ],
+                                                            "description": "The model type to use for summarization."
+                                                        },
+                                                        "minimumInputLength": {
+                                                            "type": "integer",
+                                                            "minimum": 1000,
+                                                            "maximum": 10000,
+                                                            "description": "The minimum length a section of the file should have to create a summary of it."
+                                                        },
+                                                        "outputTokenLimit": {
+                                                            "type": "integer",
+                                                            "minimum": 1000,
+                                                            "maximum": 10000,
+                                                            "description": "The maximum length of a summary (in tokens)."
+                                                        },
+                                                        "generateMasterSummary": {
+                                                            "type": "boolean",
+                                                            "description": "Generate a summary of the entire file and index it as a standalone vector."
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "stack": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "realtime-v1"
+                                                    ],
+                                                    "description": "Internal setting, cannot be set manually."
+                                                },
+                                                "vision": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "transcribePages": {
+                                                            "description": "(Team/Enterprise plan only, charged as AI Spend) For PDF files, set this option to `true` or pass an array with specific page numbers to use a vision-enabled LLM to transcribe each page of the PDF as standalone vectors and index them.\n\nThis feature is useful when a PDF file contains custom designs or layouts, or when your document has many infographics, which require visual processing in order to index the file effectively, as the default text-based indexing may not be enough to allow your bot to correctly understand the content in your PDFs.\n\nNotes:\n- This feature is only available in Team and Enterprise plans.\n- Enabling this feature will incur in AI Spend cost to use a vision-enabled LLM to index the PDF pages.\n- This is limited to a maximum of 100 pages of the PDF. If the file has more pages then the rest of the pages will NOT be transcribed using this vision feature, and will be processed using the default text-based indexing instead. If you need to transcribe the entire file using vision, please split it into smaller files.\n- Pages that are vision-transcribed will not be processed by the default text-based indexing to avoid duplicate content in the index.\n- This feature is only available for PDF files. If the file isn't a PDF, this setting will be ignored and no AI Spend will be incurred."
+                                                        },
+                                                        "indexPages": {
+                                                            "description": "(Team/Enterprise plan only, charged as AI Spend) For PDF files, set this option to `true` or pass an array with specific page numbers to use a vision-enabled LLM to index each page of the PDF as a standalone image.\n\nEnabling this feature will allow Autonomous Nodes in your bot to answer visual or higher-level questions about the content in these pages that can usually not be answered correctly by the default text-based indexing or visual transcription.\n\nThis feature is useful when a PDF has:\n- Tables with complex layouts\n- Charts, diagrams or infographics\n- Photos or images that can be used to answer user queries\n\nNotes:\n- This feature is only available in Team and Enterprise plans.\n- Enabling this will incur in extra AI Spend cost and additional File Storage usage, in order to use a vision-enabled LLM to visually index the PDF pages and store them as standalone page images in the bot's file storage.\n- Enabling this may increase the overall AI Spend cost of your bot as your bot may pass one or more indexed page images to a vision-enabled LLM for answering user queries.\n- This is limited to the first 100 pages of the PDF. If the file has more pages then the rest of the pages will NOT be vision-indexed. If you need to visually index the entire file, please split it into smaller files.\n- This feature is only available for PDF files. If the file isn't a PDF, this setting will be ignored and no AI Spend will be incurred."
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            },
+                                            "description": "Configuration to use for indexing the file, will be stored in the file's metadata for reference.",
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "configuration"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "accessPolicies": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "enum": [
+                                            "public_content",
+                                            "integrations"
+                                        ]
+                                    },
+                                    "description": "File access policies. Add \"public_content\" to allow public access to the file content. Add \"integrations\" to allow read, search and list operations for any integration installed in the bot."
+                                },
+                                "contentType": {
+                                    "type": "string",
+                                    "description": "File content type. If omitted, the content type will be inferred from the file extension (if any) specified in `key`. If a content type cannot be inferred, the default is \"application/octet-stream\"."
+                                },
+                                "expiresAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Expiry timestamp in ISO 8601 format with UTC timezone. After expiry, the File will be deleted. Must be in the future. Cannot be more than 90 days from now. The value up to minutes is considered. Seconds and milliseconds are ignored."
+                                },
+                                "publicContentImmediatelyAccessible": {
+                                    "type": "boolean",
+                                    "description": "Use when your file has \"public_content\" in its access policy and you need the file\\'s content to be immediately accessible through its URL after the file has been uploaded without having to wait for the upload to be processed by our system.\n\nIf set to `true`, the `x-amz-tagging` HTTP header with a value of `public=true` will need to be sent in the HTTP PUT request to the `uploadUrl` in order for the upload request to work."
+                                },
+                                "metadata": {
+                                    "description": "Custom metadata for the file expressed as an object of key-value pairs. The values can be of any type."
+                                }
+                            },
+                            "required": [
+                                "key",
+                                "size"
+                            ],
+                            "title": "upsertFileBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateFileMetadataBody": {
+                "description": "File metadata to update.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "metadata": {
+                                    "description": "Custom metadata for the file expressed as an object of key-value pairs. Omit to keep existing metadata intact. Any existing metadata keys not included will be preserved. New keys will be added. To delete a metadata key, set its value to `null`."
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 1000,
+                                        "nullable": true
+                                    },
+                                    "description": "The file tags to update as an object of key-value pairs with `string` (text) values. Omit to keep existing tags intact. Any existing tags not included will be preserved. New tags will be added. To delete a tag, set its value to `null`."
+                                },
+                                "accessPolicies": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "enum": [
+                                            "integrations",
+                                            "public_content"
+                                        ]
+                                    },
+                                    "description": "New access policies to set for the file. Omit to keep existing policies intact."
+                                },
+                                "expiresAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Expiry timestamp in ISO 8601 format with UTC timezone. After expiry, the File will be deleted. Must be in the future. Cannot be more than 90 days from now. The value up to minutes is considered. Seconds and milliseconds are ignored. Omit to keep the existing expiry intact. Set to `null` to remove the expiry.",
+                                    "nullable": true
+                                }
+                            },
+                            "title": "updateFileMetadataBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "copyFileBody": {
+                "description": "Additional options for file copying.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "overwrite": {
+                                    "type": "boolean",
+                                    "description": "Set to `true` to overwrite the file if it already exists, otherwise an error will be returned.\n\nWhen this endpoint is called using bot authentication, the existing file must have been originally created by the same bot making the file copy request in order to overwrite it."
+                                }
+                            },
+                            "title": "copyFileBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "setFilePassagesBody": {
+                "description": "List of passages to index for the file. These will replacing all the existing passages. Indexing of the new passages will be done asynchronously in the background. You can check the file status to see when the indexing is complete.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "passages": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "content": {
+                                                "type": "string",
+                                                "description": "The content of the passage, supports Markdown formatting."
+                                            },
+                                            "type": {
+                                                "default": "paragraph",
+                                                "type": "string",
+                                                "enum": [
+                                                    "title",
+                                                    "subtitle",
+                                                    "paragraph",
+                                                    "blockquote",
+                                                    "list",
+                                                    "table",
+                                                    "code",
+                                                    "image"
+                                                ],
+                                                "description": "The type should match the Markdown format used for the passage content."
+                                            },
+                                            "pageNumber": {
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "content"
+                                        ]
+                                    },
+                                    "description": "Note: The passages should appear in the array in the same order as they appear in the original document."
+                                }
+                            },
+                            "required": [
+                                "passages"
+                            ],
+                            "title": "setFilePassagesBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createKnowledgeBaseBody": {
+                "description": "Properties of the knowledge base.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the knowledge base."
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "title": "createKnowledgeBaseBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateKnowledgeBaseBody": {
+                "description": "Properties of the knowledge base to update.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "New name of the knowledge base."
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "title": "updateKnowledgeBaseBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "test": {
+                "name": "test",
+                "in": "header"
+            }
+        }
+    }
+}

--- a/runtime-openapi.json
+++ b/runtime-openapi.json
@@ -1,1 +1,6646 @@
-{"openapi":"3.0.0","servers":[{"url":"https://api.botpress.cloud"}],"info":{"title":"Botpress API","description":"API for Botpress Cloud","version":"1.1.0"},"paths":{"/v1/chat/conversations":{"post":{"operationId":"createConversation","description":"Creates a new [Conversation](#schema_conversation). When creating a new [Conversation](#schema_conversation), the required tags must be provided. See the specific integration for more details.","parameters":[],"responses":{"201":{"$ref":"#/components/responses/createConversationResponse"},"default":{"$ref":"#/components/responses/createConversationResponse"}},"requestBody":{"$ref":"#/components/requestBodies/createConversationBody"}},"get":{"operationId":"listConversations","description":"Retrieves a list of [Conversation](#schema_conversation) you’ve previously created. The conversations are returned in sorted order, with the most recent appearing first. The list can be filtered using [Tags](#tags).","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"sortField","in":"query","description":"Sort results by this field","schema":{"type":"string","enum":["createdAt","updatedAt"]}},{"name":"sortDirection","in":"query","description":"Sort results in this direction","schema":{"type":"string","enum":["asc","desc"]}},{"name":"tags","in":"query","description":"Filter by tags","schema":{"type":"object","additionalProperties":{"type":"string"}}},{"name":"participantIds","in":"query","description":"Filter by participant ids","schema":{"type":"array","items":{"type":"string"}}},{"name":"integrationName","in":"query","description":"Filter by integration name","schema":{"type":"string"}},{"name":"channel","in":"query","description":"Filter by integration channel name","schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/listConversationsResponse"},"default":{"$ref":"#/components/responses/listConversationsResponse"}}}},"/v1/chat/conversations/{id}":{"get":{"operationId":"getConversation","description":"Retrieves the [Conversation](#schema_conversation) object for a valid identifier.","parameters":[{"name":"id","in":"path","description":"Conversation id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/getConversationResponse"},"default":{"$ref":"#/components/responses/getConversationResponse"}}},"put":{"operationId":"updateConversation","description":"Update a [Conversation](#schema_conversation) object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.","parameters":[{"name":"id","in":"path","description":"Conversation id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/updateConversationResponse"},"default":{"$ref":"#/components/responses/updateConversationResponse"}},"requestBody":{"$ref":"#/components/requestBodies/updateConversationBody"}},"delete":{"operationId":"deleteConversation","description":"Permanently deletes a [Conversation](#schema_conversation). It cannot be undone. Also immediately deletes corresponding [Messages](#schema_message).","parameters":[{"name":"id","in":"path","description":"Conversation id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/deleteConversationResponse"},"default":{"$ref":"#/components/responses/deleteConversationResponse"}}}},"/v1/chat/conversations/get-or-create":{"post":{"operationId":"getOrCreateConversation","description":"Retrieves the [Conversation](#schema_conversation) object for a valid identifier. If the conversation does not exist, it will be created.","parameters":[],"responses":{"200":{"$ref":"#/components/responses/getOrCreateConversationResponse"},"default":{"$ref":"#/components/responses/getOrCreateConversationResponse"}},"requestBody":{"$ref":"#/components/requestBodies/getOrCreateConversationBody"}}},"/v1/chat/conversations/{id}/participants":{"get":{"operationId":"listParticipants","description":"Retrieves a list of [Participant](#schema_participant) for a given [Conversation](#schema_conversation).","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"id","in":"path","description":"Conversation id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/listParticipantsResponse"},"default":{"$ref":"#/components/responses/listParticipantsResponse"}}},"post":{"operationId":"addParticipant","description":"Add a [Participant](#schema_participant) to a [Conversation](#schema_conversation).","parameters":[{"name":"id","in":"path","description":"Conversation id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/addParticipantResponse"},"default":{"$ref":"#/components/responses/addParticipantResponse"}},"requestBody":{"$ref":"#/components/requestBodies/addParticipantBody"}}},"/v1/chat/conversations/{id}/participants/{userId}":{"get":{"operationId":"getParticipant","description":"Retrieves a [Participant](#schema_participant) from a [Conversation](#schema_conversation).","parameters":[{"name":"id","in":"path","description":"Conversation id","required":true,"schema":{"type":"string"}},{"name":"userId","in":"path","description":"User id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/getParticipantResponse"},"default":{"$ref":"#/components/responses/getParticipantResponse"}}},"delete":{"operationId":"removeParticipant","description":"Remove a [Participant](#schema_participant) from a [Conversation](#schema_conversation).","parameters":[{"name":"id","in":"path","description":"Conversation id","required":true,"schema":{"type":"string"}},{"name":"userId","in":"path","description":"User id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/removeParticipantResponse"},"default":{"$ref":"#/components/responses/removeParticipantResponse"}}}},"/v1/chat/events":{"post":{"operationId":"createEvent","description":"Creates a new [Event](#schema_event). When creating a new [Event](#schema_event), the required tags must be provided. See the specific integration for more details.","parameters":[],"responses":{"201":{"$ref":"#/components/responses/createEventResponse"},"default":{"$ref":"#/components/responses/createEventResponse"}},"requestBody":{"$ref":"#/components/requestBodies/createEventBody"}},"get":{"operationId":"listEvents","description":"Retrieves a list of [Event](#schema_event) you’ve previously created. The events are returned in sorted order, with the most recent appearing first.","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"type","in":"query","description":"Filter by event type","schema":{"type":"string"}},{"name":"conversationId","in":"query","description":"Filter by conversation id","schema":{"type":"string"}},{"name":"userId","in":"query","description":"Filter by user id","schema":{"type":"string"}},{"name":"messageId","in":"query","description":"Filter by message id","schema":{"type":"string"}},{"name":"status","in":"query","description":"Filter by status. Allowed values: pending, ignored, processed, failed.","schema":{"type":"string","enum":["pending","ignored","processed","failed","scheduled"]}}],"responses":{"200":{"$ref":"#/components/responses/listEventsResponse"},"default":{"$ref":"#/components/responses/listEventsResponse"}}}},"/v1/chat/events/{id}":{"get":{"operationId":"getEvent","description":"Retrieves the [Event](#schema_event) object for a valid identifiers.","parameters":[{"name":"id","in":"path","description":"Event id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/getEventResponse"},"default":{"$ref":"#/components/responses/getEventResponse"}}}},"/v1/chat/messages":{"post":{"operationId":"createMessage","description":"Creates a new [Message](#schema_message). When creating a new [Message](#schema_message), the required tags must be provided. See the specific integration for more details.","parameters":[],"responses":{"201":{"$ref":"#/components/responses/createMessageResponse"},"default":{"$ref":"#/components/responses/createMessageResponse"}},"requestBody":{"$ref":"#/components/requestBodies/createMessageBody"}},"get":{"operationId":"listMessages","description":"Retrieves a list of [Message](#schema_message) you’ve previously created. The messages are returned in sorted order, with the most recent appearing first. The list can be filtered using [Tags](/docs/developers/concepts/tags).","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"conversationId","in":"query","description":"Conversation id","schema":{"type":"string"}},{"name":"tags","in":"query","description":"Filter by tags","schema":{"type":"object","additionalProperties":{"type":"string"}}}],"responses":{"200":{"$ref":"#/components/responses/listMessagesResponse"},"default":{"$ref":"#/components/responses/listMessagesResponse"}}}},"/v1/chat/messages/get-or-create":{"post":{"operationId":"getOrCreateMessage","description":"Retrieves the [Message](#schema_message) object for a valid identifier. If the message does not exist, it will be created.","parameters":[],"responses":{"200":{"$ref":"#/components/responses/getOrCreateMessageResponse"},"default":{"$ref":"#/components/responses/getOrCreateMessageResponse"}},"requestBody":{"$ref":"#/components/requestBodies/getOrCreateMessageBody"}}},"/v1/chat/messages/{id}":{"get":{"operationId":"getMessage","description":"Retrieves the [Message](#schema_message) object for a valid identifier.","parameters":[{"name":"id","in":"path","description":"Id of the Message","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/getMessageResponse"},"default":{"$ref":"#/components/responses/getMessageResponse"}}},"put":{"operationId":"updateMessage","description":"Updates a message tags and payload. The message type cannot be changed. Calling this operation from an integration, to update an incoming message, will not invoke the bot. The other way around it also true; Calling this operation from the bot, to update an outgoing message, will not invoke the integration.","parameters":[{"name":"id","in":"path","description":"Message id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/updateMessageResponse"},"default":{"$ref":"#/components/responses/updateMessageResponse"}},"requestBody":{"$ref":"#/components/requestBodies/updateMessageBody"}},"delete":{"operationId":"deleteMessage","description":"Permanently deletes a [Message](#schema_message). It cannot be undone.","parameters":[{"name":"id","in":"path","description":"Message id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/deleteMessageResponse"},"default":{"$ref":"#/components/responses/deleteMessageResponse"}}}},"/v1/chat/users":{"post":{"operationId":"createUser","description":"Creates a new [User](#schema_user). When creating a new [User](#schema_user), the required tags must be provided. See the specific integration for more details.","parameters":[],"responses":{"201":{"$ref":"#/components/responses/createUserResponse"},"default":{"$ref":"#/components/responses/createUserResponse"}},"requestBody":{"$ref":"#/components/requestBodies/createUserBody"}},"get":{"operationId":"listUsers","description":"Retrieves a list of [User](#schema_user) previously created. The users are returned in sorted order, with the most recent appearing first. The list can be filtered using [Tags](/docs/developers/concepts/tags).","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"conversationId","in":"query","description":"Filter by conversation id. This will return all users that have participated in the conversation.","schema":{"type":"string"}},{"name":"tags","in":"query","description":"Filter by tags","schema":{"type":"object","additionalProperties":{"type":"string"}}}],"responses":{"200":{"$ref":"#/components/responses/listUsersResponse"},"default":{"$ref":"#/components/responses/listUsersResponse"}}}},"/v1/chat/users/{id}":{"get":{"operationId":"getUser","description":"Retrieves the [User](#schema_user) object for a valid identifier.","parameters":[{"name":"id","in":"path","description":"User ID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/getUserResponse"},"default":{"$ref":"#/components/responses/getUserResponse"}}},"put":{"operationId":"updateUser","description":"Update a [User](#schema_user) object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.","parameters":[{"name":"id","in":"path","description":"User ID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/updateUserResponse"},"default":{"$ref":"#/components/responses/updateUserResponse"}},"requestBody":{"$ref":"#/components/requestBodies/updateUserBody"}},"delete":{"operationId":"deleteUser","description":"Permanently deletes a [User](#schema_user). It cannot be undone.","parameters":[{"name":"id","in":"path","description":"User ID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/deleteUserResponse"},"default":{"$ref":"#/components/responses/deleteUserResponse"}}}},"/v1/chat/users/get-or-create":{"post":{"operationId":"getOrCreateUser","description":"Retrieves the [User](#schema_user) object for a valid identifier. If the user does not exist, it will be created.","parameters":[],"responses":{"200":{"$ref":"#/components/responses/getOrCreateUserResponse"},"default":{"$ref":"#/components/responses/getOrCreateUserResponse"}},"requestBody":{"$ref":"#/components/requestBodies/getOrCreateUserBody"}}},"/v1/chat/states/{type}/{id}/{name}/expiry":{"post":{"operationId":"setStateExpiry","description":"Updates the [State](#schema_state) expiry.","parameters":[{"name":"type","in":"path","description":"State type","required":true,"schema":{"type":"string","enum":["conversation","user","bot","integration","task","workflow"]}},{"name":"id","in":"path","description":"State id","required":true,"schema":{"type":"string"}},{"name":"name","in":"path","description":"State name","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/setStateExpiryResponse"},"default":{"$ref":"#/components/responses/setStateExpiryResponse"}},"requestBody":{"$ref":"#/components/requestBodies/setStateExpiryBody"}}},"/v1/chat/states/{type}/{id}/{name}":{"get":{"operationId":"getState","description":"Retrieves the [State](#schema_state) object for a valid identifiers.","parameters":[{"name":"type","in":"path","description":"State type","required":true,"schema":{"type":"string","enum":["conversation","user","bot","integration","task","workflow"]}},{"name":"id","in":"path","description":"State id","required":true,"schema":{"type":"string"}},{"name":"name","in":"path","description":"State name","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/getStateResponse"},"default":{"$ref":"#/components/responses/getStateResponse"}}},"post":{"operationId":"setState","description":"Overrides the [State](#schema_state) object by setting the values of the parameters passed.","parameters":[{"name":"type","in":"path","description":"State type","required":true,"schema":{"type":"string","enum":["conversation","user","bot","integration","task","workflow"]}},{"name":"id","in":"path","description":"State id","required":true,"schema":{"type":"string"}},{"name":"name","in":"path","description":"State name","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/setStateResponse"},"default":{"$ref":"#/components/responses/setStateResponse"}},"requestBody":{"$ref":"#/components/requestBodies/setStateBody"}},"patch":{"operationId":"patchState","description":"Updates the [State](#schema_state) object by setting the values of the parameters passed.","parameters":[{"name":"type","in":"path","description":"State type","required":true,"schema":{"type":"string","enum":["conversation","user","bot","integration","task","workflow"]}},{"name":"id","in":"path","description":"State id","required":true,"schema":{"type":"string"}},{"name":"name","in":"path","description":"State name","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/patchStateResponse"},"default":{"$ref":"#/components/responses/patchStateResponse"}},"requestBody":{"$ref":"#/components/requestBodies/patchStateBody"}}},"/v1/chat/states/{type}/{id}/{name}/get-or-set":{"post":{"operationId":"getOrSetState","description":"Retrieves the [State](#schema_state) object for a valid identifiers. If the state does not exist, it creates a new state.","parameters":[{"name":"type","in":"path","description":"State type","required":true,"schema":{"type":"string","enum":["conversation","user","bot","integration","task","workflow"]}},{"name":"id","in":"path","description":"State id","required":true,"schema":{"type":"string"}},{"name":"name","in":"path","description":"State name","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/getOrSetStateResponse"},"default":{"$ref":"#/components/responses/getOrSetStateResponse"}},"requestBody":{"$ref":"#/components/requestBodies/getOrSetStateBody"}}},"/v1/chat/actions":{"post":{"operationId":"callAction","description":"Call an action","parameters":[],"responses":{"200":{"$ref":"#/components/responses/callActionResponse"},"default":{"$ref":"#/components/responses/callActionResponse"}},"requestBody":{"$ref":"#/components/requestBodies/callActionBody"}}},"/v1/chat/integrations/configure":{"post":{"operationId":"configureIntegration","description":"An integration can call this endpoint to configure itself","parameters":[],"responses":{"200":{"$ref":"#/components/responses/configureIntegrationResponse"},"default":{"$ref":"#/components/responses/configureIntegrationResponse"}},"requestBody":{"$ref":"#/components/requestBodies/configureIntegrationBody"}}},"/v1/chat/tasks/{id}":{"get":{"operationId":"getTask","description":"Retrieves the [Task](#schema_task) object for a valid identifier.","parameters":[{"name":"id","in":"path","description":"Task id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/getTaskResponse"},"default":{"$ref":"#/components/responses/getTaskResponse"}}},"put":{"operationId":"updateTask","description":"Update a [Task](#schema_task) object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.","parameters":[{"name":"id","in":"path","description":"Task id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/updateTaskResponse"},"default":{"$ref":"#/components/responses/updateTaskResponse"}},"requestBody":{"$ref":"#/components/requestBodies/updateTaskBody"}},"delete":{"operationId":"deleteTask","description":"Permanently deletes a [Task](#schema_task). It cannot be undone.","parameters":[{"name":"id","in":"path","description":"Task id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/deleteTaskResponse"},"default":{"$ref":"#/components/responses/deleteTaskResponse"}}}},"/v1/chat/tasks":{"post":{"operationId":"createTask","description":"Creates a new [Task](#schema_task). When creating a new [Task](#schema_task), the required tags must be provided. See the specific integration for more details.","parameters":[],"responses":{"201":{"$ref":"#/components/responses/createTaskResponse"},"default":{"$ref":"#/components/responses/createTaskResponse"}},"requestBody":{"$ref":"#/components/requestBodies/createTaskBody"}},"get":{"operationId":"listTasks","description":"Retrieves a list of [Task](#schema_task) you've previously created. The tasks are returned in sorted order, with the most recent appearing first. The list can be filtered using [Tags](/docs/developers/concepts/tags).","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"tags","in":"query","description":"Filter by tags","schema":{"type":"object","additionalProperties":{"type":"string"}}},{"name":"conversationId","in":"query","description":"Conversation id","schema":{"type":"string"}},{"name":"userId","in":"query","description":"User id","schema":{"type":"string"}},{"name":"parentTaskId","in":"query","description":"Parent task id","schema":{"type":"string"}},{"name":"status","in":"query","description":"Status","schema":{"type":"array","items":{"type":"string","enum":["pending","in_progress","failed","completed","blocked","paused","timeout","cancelled"]}}},{"name":"type","in":"query","description":"Type","schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/listTasksResponse"},"default":{"$ref":"#/components/responses/listTasksResponse"}}}},"/v1/chat/workflows":{"post":{"operationId":"createWorkflow","description":"Creates a new [Workflow](#schema_workflow).","parameters":[],"responses":{"201":{"$ref":"#/components/responses/createWorkflowResponse"},"default":{"$ref":"#/components/responses/createWorkflowResponse"}},"requestBody":{"$ref":"#/components/requestBodies/createWorkflowBody"}},"get":{"operationId":"listWorkflows","description":"Retrieves a list of [Workflow](#schema_workflow) you've previously created. The workflows are returned in sorted order, with the most recent appearing first. The list can be filtered using [Tags](/docs/developers/concepts/tags).","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"tags","in":"query","description":"Filter by tags","schema":{"type":"object","additionalProperties":{"type":"string"}}},{"name":"conversationId","in":"query","description":"Conversation id","schema":{"type":"string"}},{"name":"userId","in":"query","description":"User id","schema":{"type":"string"}},{"name":"parentWorkflowId","in":"query","description":"Parent workflow id","schema":{"type":"string"}},{"name":"statuses","in":"query","description":"Status","schema":{"type":"array","items":{"type":"string","enum":["pending","in_progress","failed","completed","listening","paused","timedout","cancelled"]}}},{"name":"name","in":"query","description":"Workflow name","schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/listWorkflowsResponse"},"default":{"$ref":"#/components/responses/listWorkflowsResponse"}}}},"/v1/chat/workflows/{id}":{"get":{"operationId":"getWorkflow","description":"Retrieves the [Workflow](#schema_workflow) object for a valid identifier.","parameters":[{"name":"id","in":"path","description":"Workflow id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/getWorkflowResponse"},"default":{"$ref":"#/components/responses/getWorkflowResponse"}}},"put":{"operationId":"updateWorkflow","description":"Update a [Workflow](#schema_workflow) object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.","parameters":[{"name":"id","in":"path","description":"Workflow id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/updateWorkflowResponse"},"default":{"$ref":"#/components/responses/updateWorkflowResponse"}},"requestBody":{"$ref":"#/components/requestBodies/updateWorkflowBody"}},"delete":{"operationId":"deleteWorkflow","description":"Permanently deletes a [Workflow](#schema_workflow). It cannot be undone.","parameters":[{"name":"id","in":"path","description":"Workflow id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"$ref":"#/components/responses/deleteWorkflowResponse"},"default":{"$ref":"#/components/responses/deleteWorkflowResponse"}}}},"/v1/chat/workflows/get-or-create":{"post":{"operationId":"getOrCreateWorkflow","description":"Get a workflow by tags or creates a new [Workflow](#schema_workflow) if it doesn't exists.","parameters":[],"responses":{"200":{"$ref":"#/components/responses/getOrCreateWorkflowResponse"},"default":{"$ref":"#/components/responses/getOrCreateWorkflowResponse"}},"requestBody":{"$ref":"#/components/requestBodies/getOrCreateWorkflowBody"}}},"/v1/chat/tags/{key}/values":{"get":{"operationId":"listTagValues","description":"Get a bot tag values","parameters":[{"name":"nextToken","in":"query","description":"Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results","schema":{"type":"string"}},{"name":"key","in":"path","description":"Tag key","required":true,"schema":{"type":"string"}},{"name":"type","in":"query","description":"Tag type","required":true,"schema":{"type":"string","enum":["user","conversation","message"]}}],"responses":{"200":{"$ref":"#/components/responses/listTagValuesResponse"},"default":{"$ref":"#/components/responses/listTagValuesResponse"}}}},"/v1/chat/analytics":{"post":{"operationId":"trackAnalytics","description":"Add an event to the analytics","parameters":[],"responses":{"200":{"$ref":"#/components/responses/trackAnalyticsResponse"},"default":{"$ref":"#/components/responses/trackAnalyticsResponse"}},"requestBody":{"$ref":"#/components/requestBodies/trackAnalyticsBody"}}}},"components":{"schemas":{"Bot":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [Bot](#schema_bot)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [Bot](#schema_bot) in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Updating date of the [Bot](#schema_bot) in ISO 8601 format"},"signingSecret":{"type":"string","maxLength":2000,"description":"Signing secret of the [Bot](#schema_bot)"},"integrations":{"type":"object","additionalProperties":{"type":"object","properties":{"enabled":{"type":"boolean"},"name":{"type":"string","maxLength":200,"description":"Name of the [Integration](#schema_integration)"},"version":{"type":"string","maxLength":200,"description":"Version of the [Integration](#schema_integration)"},"webhookUrl":{"type":"string","maxLength":2000},"webhookId":{"type":"string","maxLength":200},"identifier":{"type":"string","maxLength":2000},"configurationType":{"type":"string","maxLength":200,"nullable":true},"configuration":{"type":"object","additionalProperties":true},"status":{"type":"string","enum":["registration_pending","registered","registration_failed","unregistration_pending","unregistered","unregistration_failed"]},"statusReason":{"type":"string","maxLength":2000,"nullable":true},"id":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Integration](#schema_integration)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [Integration](#schema_integration) in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Updating date of the [Integration](#schema_integration) in ISO 8601 format"},"title":{"type":"string","minLength":1,"maxLength":64,"description":"Title of the integration. This is the name that will be displayed in the UI"},"description":{"type":"string","maxLength":256,"description":"Description of the integration. This is the description that will be displayed in the UI"},"iconUrl":{"type":"string","description":"URL of the icon of the integration. This is the icon that will be displayed in the UI"},"public":{"type":"boolean","description":"Idicates if the integration is public. Public integrations are available to all and cannot be updated without creating a new version."},"verificationStatus":{"type":"string","enum":["unapproved","pending","approved","rejected"],"description":"Status of the integration version verification"}},"required":["enabled","name","version","webhookUrl","webhookId","configurationType","configuration","status","statusReason","id","createdAt","updatedAt","title","description","iconUrl","public","verificationStatus"],"additionalProperties":false},"description":"A mapping of integrations to their configuration"},"user":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the tag"},"description":{"type":"string","maxLength":256,"description":"Description of the tag"}},"description":"Definition of a tag that can be provided on the object","additionalProperties":false}}},"required":["tags"],"description":"User object configuration","additionalProperties":false},"conversation":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the tag"},"description":{"type":"string","maxLength":256,"description":"Description of the tag"}},"description":"Definition of a tag that can be provided on the object","additionalProperties":false}}},"required":["tags"],"description":"Conversation object configuration","additionalProperties":false},"message":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the tag"},"description":{"type":"string","maxLength":256,"description":"Description of the tag"}},"description":"Definition of a tag that can be provided on the object","additionalProperties":false}}},"required":["tags"],"description":"Message object configuration","additionalProperties":false},"states":{"type":"object","additionalProperties":{"type":"object","properties":{"type":{"type":"string","enum":["conversation","user","bot","task"],"description":"Type of the [State](#schema_state) (`conversation`, `user`, `bot` or `task`)"},"schema":{"type":"object","additionalProperties":true,"description":"Schema of the [State](#schema_state) in the `JSON schema` format. This `JSON schema` is going to be used for validating the state data."},"expiry":{"type":"number","minimum":1,"description":"Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."}},"required":["type","schema"],"additionalProperties":false},"description":"A mapping of states to their definition"},"configuration":{"type":"object","properties":{"data":{"type":"object","additionalProperties":true,"description":"Configuration data"},"schema":{"type":"object","additionalProperties":true,"description":"Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."}},"required":["data","schema"],"description":"Configuration of the bot","additionalProperties":false},"events":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the event"},"description":{"type":"string","maxLength":256,"description":"Description of the event"},"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"description":"Event Definition","additionalProperties":false},"description":"Events definition"},"recurringEvents":{"type":"object","additionalProperties":{"type":"object","properties":{"schedule":{"type":"object","properties":{"cron":{"type":"string","maxLength":200}},"required":["cron"],"additionalProperties":false},"type":{"type":"string","maxLength":200},"payload":{"type":"object","additionalProperties":true},"failedAttempts":{"type":"number","description":"The number of times the recurring event failed to run. This counter resets once the recurring event runs successfully."},"lastFailureReason":{"type":"string","maxLength":2000,"description":"The reason why the recurring event failed to run in the last attempt.","nullable":true}},"required":["schedule","type","payload","failedAttempts","lastFailureReason"],"additionalProperties":false},"description":"Recurring events"},"subscriptions":{"type":"object","properties":{"events":{"type":"object","additionalProperties":{"type":"object","additionalProperties":false},"nullable":true,"description":"Events that the bot is currently subscribed on (ex: \"slack:reactionAdded\"). If null, the bot is subscribed to all events."}},"required":["events"],"description":"Subscriptions of the bot","additionalProperties":false},"actions":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the action"},"description":{"type":"string","maxLength":256,"description":"Description of the action"},"billable":{"type":"boolean"},"cacheable":{"type":"boolean"},"input":{"type":"object","properties":{"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"additionalProperties":false},"output":{"type":"object","properties":{"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"additionalProperties":false}},"required":["input","output"],"description":"Action definition","additionalProperties":false},"description":"Actions definition"},"tags":{"type":"object","additionalProperties":{"type":"string"},"description":"Tags of [Bot](#schema_bot)"},"name":{"type":"string","description":"Name of the [Bot](#schema_bot)"},"deployedAt":{"type":"string","format":"date-time","description":"Last deployment date of the [Bot](#schema_bot) in the ISO 8601 format"},"dev":{"type":"boolean","description":"Indicates if the [Bot](#schema_bot) is a development bot; Development bots run locally and can install dev integrations"},"createdBy":{"type":"string","description":"Id of the user that created the bot"},"alwaysAlive":{"type":"boolean","description":"Indicates if the [Bot](#schema_bot) should be in always alive mode"},"status":{"type":"string","enum":["active","deploying"],"description":"Status of the bot"},"medias":{"type":"array","items":{"type":"object","properties":{"url":{"type":"string","description":"URL of the media file"},"name":{"type":"string","description":"Name of the media file"}},"required":["url","name"]},"description":"Media files associated with the [Bot](#schema_bot)"}},"required":["id","createdAt","updatedAt","signingSecret","integrations","user","conversation","message","states","configuration","events","recurringEvents","subscriptions","actions","tags","name","dev","alwaysAlive","status","medias"],"additionalProperties":false},"Integration":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Integration](#schema_integration)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [Integration](#schema_integration) in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Updating date of the [Integration](#schema_integration) in ISO 8601 format"},"identifier":{"type":"object","properties":{"fallbackHandlerScript":{"type":"string","maxLength":2000,"description":"VRL Script of the [Integration](#schema_integration) to handle incoming requests for a request that doesn't have an identifier"},"extractScript":{"type":"string","maxLength":2000,"description":"VRL Script of the [Integration](#schema_integration) to extract the identifier from an incoming webhook often use for OAuth"}},"description":"Global identifier configuration of the [Integration](#schema_integration)","additionalProperties":false},"sandbox":{"type":"object","properties":{"identifierExtractScript":{"type":"string","maxLength":2000,"description":"VRL Script of the [Integration](#schema_integration) to extract the identifier from an incoming webhook used specifically for the sandbox"},"messageExtractScript":{"type":"string","maxLength":2000,"description":"VRL Script of the [Integration](#schema_integration) to extract the message from an incoming webhook used specifically for the sandbox"}},"additionalProperties":false},"url":{"type":"string","maxLength":2000,"description":"URL of the [Integration](#schema_integration)"},"name":{"type":"string","maxLength":200,"description":"Name of the [Integration](#schema_integration)"},"version":{"type":"string","maxLength":200,"description":"Version of the [Integration](#schema_integration)"},"interfaces":{"type":"object","additionalProperties":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the interface"},"name":{"type":"string","maxLength":200,"description":"Name of the interface"},"version":{"type":"string","maxLength":200,"description":"Version of the interface"},"entities":{"type":"object","additionalProperties":{"type":"object","properties":{"name":{"type":"string","maxLength":200}},"required":["name"],"additionalProperties":false}},"actions":{"type":"object","additionalProperties":{"type":"object","properties":{"name":{"type":"string","maxLength":200}},"required":["name"],"additionalProperties":false}},"events":{"type":"object","additionalProperties":{"type":"object","properties":{"name":{"type":"string","maxLength":200}},"required":["name"],"additionalProperties":false}},"channels":{"type":"object","additionalProperties":{"type":"object","properties":{"name":{"type":"string","maxLength":200}},"required":["name"],"additionalProperties":false}}},"required":["id","name","version","entities","actions","events","channels"],"additionalProperties":false}},"configuration":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the configuration"},"description":{"type":"string","maxLength":256,"description":"Description of the configuration"},"identifier":{"type":"object","properties":{"linkTemplateScript":{"type":"string","maxLength":2000},"required":{"type":"boolean"}},"required":["required"],"description":"Identifier configuration of the [Integration](#schema_integration)","additionalProperties":false},"schema":{"type":"object","additionalProperties":true,"description":"Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."}},"required":["identifier","schema"],"description":"Configuration definition","additionalProperties":false},"configurations":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the configuration"},"description":{"type":"string","maxLength":256,"description":"Description of the configuration"},"identifier":{"type":"object","properties":{"linkTemplateScript":{"type":"string","maxLength":2000},"required":{"type":"boolean"}},"required":["required"],"description":"Identifier configuration of the [Integration](#schema_integration)","additionalProperties":false},"schema":{"type":"object","additionalProperties":true,"description":"Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."}},"required":["identifier","schema"],"description":"Configuration definition","additionalProperties":false}},"channels":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the channel"},"description":{"type":"string","maxLength":256,"description":"Description of the channel"},"messages":{"type":"object","additionalProperties":{"type":"object","properties":{"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"description":"Message definition","additionalProperties":false}},"conversation":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the tag"},"description":{"type":"string","maxLength":256,"description":"Description of the tag"}},"description":"Definition of a tag that can be provided on the object","additionalProperties":false}},"creation":{"type":"object","properties":{"enabled":{"type":"boolean","description":"Enable conversation creation"},"requiredTags":{"type":"array","items":{"type":"string"},"description":"The list of tags that are required to be specified when calling the API directly to create a conversation."}},"required":["enabled","requiredTags"],"description":"The conversation creation setting determines how to create a conversation through the API directly. The integration will have to implement the `createConversation` functionality to support this setting.","additionalProperties":false}},"required":["tags","creation"],"description":"Conversation object configuration","additionalProperties":false},"message":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the tag"},"description":{"type":"string","maxLength":256,"description":"Description of the tag"}},"description":"Definition of a tag that can be provided on the object","additionalProperties":false}}},"required":["tags"],"description":"Message object configuration","additionalProperties":false}},"required":["messages","conversation","message"],"description":"Channel definition","additionalProperties":false}},"states":{"type":"object","additionalProperties":{"type":"object","properties":{"type":{"type":"string","enum":["conversation","user","integration"],"description":"Type of the [State](#schema_state) (`conversation`, `user` or `integration`)"},"schema":{"type":"object","additionalProperties":true,"description":"Schema of the [State](#schema_state) in the `JSON schema` format. This `JSON schema` is going to be used for validating the state data."}},"required":["type","schema"],"description":"State definition","additionalProperties":false}},"events":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the event"},"description":{"type":"string","maxLength":256,"description":"Description of the event"},"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"description":"Event Definition","additionalProperties":false}},"actions":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the action"},"description":{"type":"string","maxLength":256,"description":"Description of the action"},"billable":{"type":"boolean"},"cacheable":{"type":"boolean"},"input":{"type":"object","properties":{"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"additionalProperties":false},"output":{"type":"object","properties":{"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"additionalProperties":false}},"required":["input","output"],"description":"Action definition","additionalProperties":false}},"user":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the tag"},"description":{"type":"string","maxLength":256,"description":"Description of the tag"}},"description":"Definition of a tag that can be provided on the object","additionalProperties":false}},"creation":{"type":"object","properties":{"enabled":{"type":"boolean","description":"Enable user creation"},"requiredTags":{"type":"array","items":{"type":"string"},"description":"The list of tags that are required to be specified when calling the API directly to create a user."}},"required":["enabled","requiredTags"],"description":"The user creation setting determines how to create a user through the API directly. The integration will have to implement the `createUser` functionality to support this setting.","additionalProperties":false}},"required":["tags","creation"],"description":"User object configuration","additionalProperties":false},"entities":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the entity"},"description":{"type":"string","maxLength":256,"description":"Description of the entity"},"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"description":"Entity definition","additionalProperties":false}},"dev":{"type":"boolean","description":"Indicates if the integration is a development integration; Dev integrations run locally"},"title":{"type":"string","minLength":1,"maxLength":64,"description":"Title of the integration. This is the name that will be displayed in the UI"},"description":{"type":"string","maxLength":256,"description":"Description of the integration. This is the description that will be displayed in the UI"},"iconUrl":{"type":"string","description":"URL of the icon of the integration. This is the icon that will be displayed in the UI"},"readmeUrl":{"type":"string","description":"URL of the readme of the integration. This is the readme that will be displayed in the UI"},"public":{"type":"boolean","description":"Idicates if the integration is public. Public integrations are available to all and cannot be updated without creating a new version."},"verificationStatus":{"type":"string","enum":["unapproved","pending","approved","rejected"],"description":"Status of the integration version verification"},"secrets":{"type":"array","items":{"type":"string"},"description":"Secrets are integration-wide values available in the code via environment variables formatted with a SECRET_ prefix followed by your secret name. A secret name must respect SCREAMING_SNAKE casing."}},"required":["id","createdAt","updatedAt","identifier","url","name","version","interfaces","configuration","configurations","channels","states","events","actions","user","entities","dev","title","description","iconUrl","readmeUrl","public","verificationStatus","secrets"],"additionalProperties":false},"Interface":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Interface](#schema_interface)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [Interface](#schema_interface) in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Updating date of the [Interface](#schema_interface) in ISO 8601 format"},"name":{"type":"string","maxLength":200,"description":"Name of the [Interface](#schema_interface)"},"version":{"type":"string","maxLength":200,"description":"Version of the [Interface](#schema_interface)"},"entities":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the entity"},"description":{"type":"string","maxLength":256,"description":"Description of the entity"},"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"description":"Entity definition","additionalProperties":false}},"events":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the event"},"description":{"type":"string","maxLength":256,"description":"Description of the event"},"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"description":"Event Definition","additionalProperties":false}},"actions":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the action"},"description":{"type":"string","maxLength":256,"description":"Description of the action"},"billable":{"type":"boolean"},"cacheable":{"type":"boolean"},"input":{"type":"object","properties":{"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"additionalProperties":false},"output":{"type":"object","properties":{"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"additionalProperties":false}},"required":["input","output"],"description":"Action definition","additionalProperties":false}},"channels":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the channel"},"description":{"type":"string","maxLength":256,"description":"Description of the channel"},"messages":{"type":"object","additionalProperties":{"type":"object","properties":{"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"description":"Message definition","additionalProperties":false}}},"required":["messages"],"additionalProperties":false}},"nameTemplate":{"type":"object","properties":{"script":{"type":"string","maxLength":2000},"language":{"type":"string","maxLength":200}},"required":["script","language"],"description":"Template string optionaly used at build time by integrations implementing this interface to pick a name for actions and events.","additionalProperties":false}},"required":["id","createdAt","updatedAt","name","version","entities","events","actions","channels"],"additionalProperties":false},"Plugin":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Plugin](#schema_plugin)"},"name":{"type":"string","maxLength":200,"description":"Name of the [Plugin](#schema_plugin)"},"version":{"type":"string","maxLength":200,"description":"Version of the [Plugin](#schema_plugin)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [Plugin](#schema_plugin) in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Updating date of the [Plugin](#schema_plugin) in ISO 8601 format"},"configuration":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the configuration"},"description":{"type":"string","maxLength":256,"description":"Description of the configuration"},"schema":{"type":"object","additionalProperties":true,"description":"Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."}},"required":["schema"],"description":"Configuration definition","additionalProperties":false},"states":{"type":"object","additionalProperties":{"type":"object","properties":{"type":{"type":"string","enum":["conversation","user","bot","task"],"description":"Type of the [State](#schema_state) (`conversation`, `user`, `bot` or `task`)"},"schema":{"type":"object","additionalProperties":true,"description":"Schema of the [State](#schema_state) in the `JSON schema` format. This `JSON schema` is going to be used for validating the state data."},"expiry":{"type":"number","minimum":1,"description":"Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."}},"required":["type","schema"],"additionalProperties":false}},"events":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the event"},"description":{"type":"string","maxLength":256,"description":"Description of the event"},"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"description":"Event Definition","additionalProperties":false}},"actions":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the action"},"description":{"type":"string","maxLength":256,"description":"Description of the action"},"billable":{"type":"boolean"},"cacheable":{"type":"boolean"},"input":{"type":"object","properties":{"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"additionalProperties":false},"output":{"type":"object","properties":{"schema":{"type":"object","additionalProperties":true}},"required":["schema"],"additionalProperties":false}},"required":["input","output"],"description":"Action definition","additionalProperties":false}},"dependencies":{"type":"object","properties":{"interfaces":{"type":"object","additionalProperties":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36},"name":{"type":"string","maxLength":200},"version":{"type":"string","maxLength":200}},"required":["id","name","version"],"additionalProperties":false}},"integrations":{"type":"object","additionalProperties":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36},"name":{"type":"string","maxLength":200},"version":{"type":"string","maxLength":200}},"required":["id","name","version"],"additionalProperties":false}}},"required":["interfaces","integrations"],"additionalProperties":false},"user":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the tag"},"description":{"type":"string","maxLength":256,"description":"Description of the tag"}},"description":"Definition of a tag that can be provided on the object","additionalProperties":false}}},"required":["tags"],"description":"User object configuration","additionalProperties":false},"conversation":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"object","properties":{"title":{"type":"string","maxLength":64,"description":"Title of the tag"},"description":{"type":"string","maxLength":256,"description":"Description of the tag"}},"description":"Definition of a tag that can be provided on the object","additionalProperties":false}}},"required":["tags"],"description":"Conversation object configuration","additionalProperties":false},"title":{"type":"string","minLength":1,"maxLength":64,"description":"Title of the plugin. This is the name that will be displayed in the UI"},"description":{"type":"string","maxLength":256,"description":"Description of the plugin. This is the description that will be displayed in the UI"},"iconUrl":{"type":"string","description":"URL of the icon of the plugin. This is the icon that will be displayed in the UI"},"readmeUrl":{"type":"string","description":"URL of the readme of the plugin. This is the readme that will be displayed in the UI"}},"required":["id","name","version","createdAt","updatedAt","configuration","states","events","actions","dependencies","user","conversation","title","description","iconUrl","readmeUrl"],"additionalProperties":false},"Workspace":{"type":"object","properties":{"id":{"type":"string"},"name":{"type":"string"},"ownerId":{"type":"string"},"createdAt":{"type":"string"},"updatedAt":{"type":"string"},"botCount":{"type":"number"},"billingVersion":{"type":"string","enum":["v1","v2","v3"]},"plan":{"type":"string","enum":["community","team","enterprise","plus"]},"blocked":{"type":"boolean"},"spendingLimit":{"type":"number"},"about":{"default":"","type":"string"},"profilePicture":{"default":"","type":"string"},"contactEmail":{"default":"","type":"string"},"website":{"default":"","type":"string"},"socialAccounts":{"default":[],"type":"array","items":{"type":"string"}},"isPublic":{"type":"boolean"},"handle":{"default":"","type":"string"}},"required":["id","name","ownerId","createdAt","updatedAt","botCount","billingVersion","plan","blocked","spendingLimit"],"additionalProperties":false},"WorkspaceMember":{"type":"object","properties":{"id":{"type":"string"},"userId":{"type":"string","format":"uuid"},"email":{"type":"string"},"createdAt":{"type":"string"},"role":{"type":"string","enum":["viewer","billing","developer","manager","administrator","owner"]},"profilePicture":{"type":"string"},"displayName":{"type":"string","maxLength":100}},"required":["id","email","createdAt","role"],"additionalProperties":false},"Account":{"type":"object","properties":{"id":{"type":"string"},"email":{"type":"string"},"displayName":{"type":"string","maxLength":100},"emailVerified":{"type":"boolean"},"profilePicture":{"type":"string"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [Account](#schema_account) in ISO 8601 format"}},"required":["id","email","emailVerified","createdAt"],"additionalProperties":false},"Usage":{"type":"object","properties":{"id":{"type":"string","description":"Id of the usage that it is linked to. It can either be a workspace id or a bot id"},"period":{"type":"string","description":"Period of the quota that it is applied to"},"value":{"type":"number","description":"Value of the current usage"},"quota":{"type":"number","description":"Quota of the current usage"},"type":{"type":"string","enum":["invocation_timeout","invocation_calls","storage_count","bot_count","knowledgebase_vector_storage","workspace_ratelimit","table_row_count","workspace_member_count","integrations_owned_count","ai_spend","openai_spend","bing_search_spend","always_alive"],"description":"Usage type that can be used"}},"required":["id","period","value","quota","type"],"additionalProperties":false},"Issue":{"type":"object","properties":{"id":{"type":"string"},"code":{"type":"string"},"createdAt":{"type":"string","format":"date-time"},"lastSeenAt":{"type":"string","format":"date-time"},"title":{"type":"string"},"description":{"type":"string"},"groupedData":{"type":"object","additionalProperties":{"type":"object","properties":{"raw":{"type":"string"},"pretty":{"type":"string"}},"required":["raw"],"additionalProperties":false}},"eventsCount":{"type":"number"},"category":{"type":"string","enum":["user_code","limits","configuration","other"]},"resolutionLink":{"type":"string","nullable":true}},"required":["id","code","createdAt","lastSeenAt","title","description","groupedData","eventsCount","category","resolutionLink"],"additionalProperties":false},"IssueEvent":{"type":"object","properties":{"id":{"type":"string"},"createdAt":{"type":"string","format":"date-time"},"data":{"type":"object","additionalProperties":{"type":"object","properties":{"raw":{"type":"string"},"pretty":{"type":"string"}},"required":["raw"],"additionalProperties":false}}},"required":["id","createdAt","data"],"additionalProperties":false},"Activity":{"type":"object","properties":{"id":{"type":"string"},"description":{"type":"string"},"taskId":{"type":"string"},"category":{"type":"string","enum":["unknown","capture","bot_message","user_message","agent_message","event","action","task_status","subtask_status","exception"]},"data":{"type":"object","additionalProperties":true},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the activity in ISO 8601 format"}},"required":["id","description","taskId","category","data","createdAt"],"additionalProperties":false},"Version":{"type":"object","properties":{"id":{"type":"string"},"name":{"type":"string"},"description":{"type":"string"}},"required":["id","name"],"additionalProperties":false},"User":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [User](#schema_user)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [User](#schema_user) in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Updating date of the [User](#schema_user) in ISO 8601 format"},"tags":{"type":"object","additionalProperties":{"type":"string"},"description":"Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [User](#schema_user). The set of [Tags](/docs/developers/concepts/tags) available on a [User](#schema_user) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."},"name":{"type":"string","maxLength":200,"description":"Name of the [User](#schema_user)"},"pictureUrl":{"type":"string","maxLength":40000,"description":"Picture URL of the [User](#schema_user)"}},"required":["id","createdAt","updatedAt","tags"],"description":"The user object represents someone interacting with the bot within a specific integration. The same person interacting with a bot in slack and messenger will be represented with two different users.","additionalProperties":false},"Conversation":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [Conversation](#schema_conversation)"},"currentTaskId":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the current [Task](#schema_task)"},"currentWorkflowId":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the current [Workflow](#schema_workflow)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [Conversation](#schema_conversation) in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Updating date of the [Conversation](#schema_conversation) in ISO 8601 format"},"channel":{"type":"string","description":"Name of the channel where the [Conversation](#schema_conversation) is happening"},"integration":{"type":"string","description":"Name of the integration that created the [Conversation](#schema_conversation)"},"tags":{"type":"object","additionalProperties":{"type":"string"},"description":"Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Conversation](#schema_conversation). The set of [Tags](/docs/developers/concepts/tags) available on a [Conversation](#schema_conversation) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."}},"required":["id","createdAt","updatedAt","channel","integration","tags"],"description":"The [Conversation](#schema_conversation) object represents an exchange of messages between one or more users. A [Conversation](#schema_conversation) is always linked to an integration's channels. For example, a Slack channel represents a conversation.","additionalProperties":false},"Event":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [Event](#schema_event)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [Event](#schema_event) in ISO 8601 format"},"type":{"type":"string","maxLength":200,"description":"Type of the [Event](#schema_event)."},"payload":{"type":"object","additionalProperties":true,"description":"Payload is the content of the event defined by the integration installed on your bot or one of the default events created by our api."},"conversationId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Conversation](#schema_conversation) to link the event to."},"userId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [User](#schema_user) to link the event to."},"messageId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Message](#schema_message) to link the event to."},"status":{"type":"string","enum":["pending","processed","ignored","failed","scheduled"]},"failureReason":{"type":"string","maxLength":2000,"nullable":true,"description":"Reason why the event failed to be processed"}},"required":["id","createdAt","type","payload","status","failureReason"],"description":"The event object represents an action or an occurrence.","additionalProperties":false},"Message":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [Message](#schema_message)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [Message](#schema_message) in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Update date of the [Message](#schema_message) in ISO 8601 format"},"type":{"type":"string","maxLength":200,"description":"Type of the [Message](#schema_message) represents the resource type that the message is related to"},"payload":{"type":"object","additionalProperties":true,"description":"Payload is the content type of the message. Accepted payload options: Text, Image, Choice, Dropdown, Card, Carousel, File, Audio, Video, Location"},"direction":{"type":"string","enum":["incoming","outgoing"],"description":"Direction of the message (`incoming` or `outgoing`)."},"userId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [User](#schema_user)"},"conversationId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Conversation](#schema_conversation)"},"tags":{"type":"object","additionalProperties":{"type":"string"},"description":"Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Conversation](#schema_conversation). The set of [Tags](/docs/developers/concepts/tags) available on a [Conversation](#schema_conversation) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."}},"required":["id","createdAt","updatedAt","type","payload","direction","userId","conversationId","tags"],"description":"The Message object represents a message in a [Conversation](#schema_conversation) for a specific [User](#schema_user).","additionalProperties":false},"State":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [State](#schema_state)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [State](#schema_state) in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Updating date of the [State](#schema_state) in ISO 8601 format"},"botId":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [Bot](#schema_bot)"},"conversationId":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [Conversation](#schema_conversation)"},"userId":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [User](#schema_user)"},"name":{"type":"string","maxLength":200,"description":"Name of the [State](#schema_state) which is declared inside the bot definition"},"type":{"type":"string","enum":["conversation","user","bot","task","integration","workflow"],"description":"Type of the [State](#schema_state) represents the resource type (`conversation`, `user`, `bot`, `task`, `integration` or `workflow`) that the state is related to"},"payload":{"type":"object","additionalProperties":true,"description":"Payload is the content of the state defined by your bot."}},"required":["id","createdAt","updatedAt","botId","name","type","payload"],"description":"The state object represents the current payload. A state is always linked to either a bot, a conversation or a user.","additionalProperties":false},"Task":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [Task](#schema_task)"},"title":{"type":"string","maxLength":64,"description":"Title describing the task"},"description":{"type":"string","maxLength":256,"description":"All the notes related to the execution of the current task"},"type":{"type":"string","description":"Type of the task"},"data":{"type":"object","additionalProperties":true,"description":"Content related to the task"},"status":{"type":"string","enum":["pending","in_progress","failed","completed","blocked","paused","timeout","cancelled"],"description":"Status of the task"},"parentTaskId":{"type":"string","minLength":28,"maxLength":36,"description":"Parent task id is the parent task that created this task"},"conversationId":{"type":"string","minLength":28,"maxLength":36,"description":"Conversation id related to this task"},"userId":{"type":"string","minLength":28,"maxLength":36,"description":"Specific user related to this task"},"timeoutAt":{"type":"string","format":"date-time","description":"The timeout date where the task should be failed in the ISO 8601 format"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the task in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Updating date of the task in ISO 8601 format"},"failureReason":{"type":"string","maxLength":2000,"description":"If the task fails this is the reason behind it"},"tags":{"type":"object","additionalProperties":{"type":"string"},"description":"Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Task](#schema_task). Individual keys can be unset by posting an empty value to them."}},"required":["id","title","description","type","data","status","timeoutAt","createdAt","updatedAt","tags"],"description":"Task definition","additionalProperties":false},"Workflow":{"type":"object","properties":{"id":{"type":"string","minLength":28,"maxLength":36,"description":"Id of the [Workflow](#schema_workflow)"},"name":{"type":"string","maxLength":200,"description":"Name of the workflow"},"status":{"type":"string","enum":["pending","in_progress","failed","completed","listening","paused","timedout","cancelled"],"description":"Status of the [Workflow](#schema_workflow)"},"input":{"type":"object","additionalProperties":true,"description":"Input provided to the [Workflow](#schema_workflow)"},"output":{"type":"object","additionalProperties":true,"description":"Data returned by the [Workflow](#schema_workflow) output"},"parentWorkflowId":{"type":"string","minLength":28,"maxLength":36,"description":"Parent [Workflow](#schema_workflow) id is the parent [Workflow](#schema_workflow) that created this [Workflow](#schema_workflow)"},"conversationId":{"type":"string","minLength":28,"maxLength":36,"description":"Conversation id related to this [Workflow](#schema_workflow)"},"userId":{"type":"string","minLength":28,"maxLength":36,"description":"User id related to this [Workflow](#schema_workflow)"},"createdAt":{"type":"string","format":"date-time","description":"Creation date of the [Workflow](#schema_workflow) in ISO 8601 format"},"updatedAt":{"type":"string","format":"date-time","description":"Updating date of the [Workflow](#schema_workflow) in ISO 8601 format"},"completedAt":{"type":"string","format":"date-time","description":"The date when the [Workflow](#schema_workflow) completed in ISO 8601 format"},"failureReason":{"type":"string","maxLength":2000,"description":"If the [Workflow](#schema_workflow) fails this is the reason behind it"},"timeoutAt":{"type":"string","format":"date-time","description":"The timeout date when the [Workflow](#schema_workflow) will fail in the ISO 8601 format"},"tags":{"type":"object","additionalProperties":{"type":"string"},"description":"Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Workflow](#schema_workflow). Individual keys can be unset by posting an empty value to them."}},"required":["id","name","status","input","output","createdAt","updatedAt","timeoutAt","tags"],"description":"Workflow definition","additionalProperties":false},"Table":{"type":"object","properties":{"id":{"type":"string","description":"Unique identifier for the table"},"name":{"description":"Required. This name is used to identify your table.","type":"string","minLength":1},"factor":{"default":1,"type":"number","minimum":1,"maximum":30,"description":"The 'factor' multiplies the row's data storage limit by 4KB and its quota count, but can only be set at table creation and not modified later. For instance, a factor of 2 increases storage to 8KB but counts as 2 rows in your quota. The default factor is 1."},"frozen":{"type":"boolean","description":"A table designated as \"frozen\" is immutable in terms of its name and schema structure; modifications to its schema or a renaming operation are not permitted. The only action that can be taken on such a table is deletion. The schema established at the time of creation is locked in as the final structure. To implement any changes, the table must be duplicated with the desired alterations."},"schema":{"type":"object","properties":{"$schema":{"type":"string"},"properties":{"type":"object","additionalProperties":{"type":"object","properties":{"type":{"type":"string","enum":["string","number","boolean","object","array","null"]},"format":{"type":"string","enum":["date-time"]},"description":{"type":"string"},"pattern":{"type":"string","description":"String properties must match this pattern"},"enum":{"type":"array","items":{"type":"string"},"description":"String properties must be one of these values"},"items":{"type":"object","properties":{"type":{"type":"string","enum":["string","number","boolean","object","array","null"]}},"required":["type"],"additionalProperties":true,"description":"Defines the shape of items in an array"},"nullable":{"default":true,"type":"boolean"},"properties":{"type":"object","additionalProperties":{"type":"object","properties":{"type":{"type":"string","enum":["string","number","boolean","object","array","null"]}},"required":["type"],"additionalProperties":true}},"x-zui":{"type":"object","properties":{"index":{"type":"integer"},"id":{"type":"string","description":"[deprecated] ID of the column."},"searchable":{"type":"boolean","description":"Indicates if the column is vectorized and searchable."},"hidden":{"type":"boolean","description":"Indicates if the field is hidden in the UI"},"order":{"type":"number","description":"Order of the column in the UI"},"width":{"type":"number","description":"Width of the column in the UI"},"schemaId":{"type":"string","description":"ID of the schema"},"computed":{"type":"object","properties":{"action":{"type":"string","enum":["ai","code","workflow"]},"dependencies":{"default":[],"type":"array","items":{"type":"string"}},"prompt":{"type":"string","description":"Prompt when action is \"ai\""},"code":{"type":"string","description":"Code to execute when action is \"code\""},"model":{"default":"gpt-4o","type":"string","maxLength":80,"description":"Model to use when action is \"ai\""},"workflowId":{"type":"string","maxLength":20,"description":"ID of Workflow to execute when action is \"workflow\""},"enabled":{"type":"boolean"}},"required":["action"],"additionalProperties":false},"typings":{"type":"string","description":"TypeScript typings for the column. Recommended if the type is \"object\", ex: \"\\{ foo: string; bar: number \\}\""}},"required":["index"],"additionalProperties":false}},"required":["type","x-zui"],"additionalProperties":false},"description":"List of keys/columns in the table."},"additionalProperties":{"type":"boolean","enum":[true],"description":"Additional properties can be provided, but they will be ignored if no column matches."},"required":{"type":"array","items":{"type":"string"},"description":"Array of required properties."},"type":{"type":"string","enum":["object"]}},"required":["properties","additionalProperties","type"],"additionalProperties":false},"tags":{"type":"object","additionalProperties":{"type":"string"},"description":"Optional tags to help organize your tables. These should be passed here as an object representing key/value pairs."},"isComputeEnabled":{"type":"boolean","description":"Indicates if the table is enabled for computation."},"createdAt":{"type":"string","format":"date-time","description":"Timestamp of table creation."},"updatedAt":{"type":"string","format":"date-time","description":"Timestamp of the last table update."}},"required":["id","name","schema"],"additionalProperties":false},"Column":{"type":"object","properties":{"id":{"type":"string","description":"Unique identifier for the column."},"name":{"type":"string","minLength":1,"maxLength":30,"description":"Name of the column, must be within length limits."},"description":{"type":"string","description":"Optional descriptive text about the column."},"searchable":{"type":"boolean","description":"Indicates if the column is vectorized and searchable."},"type":{"type":"string","enum":["string","number","boolean","date","object"],"description":"Specifies the data type of the column. Use \"object\" for complex data structures."},"typings":{"type":"string","description":"TypeScript typings for the column. Recommended if the type is \"object\", ex: \"\\{ foo: string; bar: number \\}\""},"computed":{"type":"object","properties":{"action":{"type":"string","enum":["ai","code","workflow"]},"dependencies":{"default":[],"type":"array","items":{"type":"string"}},"prompt":{"type":"string","description":"Prompt when action is \"ai\""},"code":{"type":"string","description":"Code to execute when action is \"code\""},"model":{"default":"gpt-4o","type":"string","maxLength":80,"description":"Model to use when action is \"ai\""},"workflowId":{"type":"string","maxLength":20,"description":"ID of Workflow to execute when action is \"workflow\""},"enabled":{"type":"boolean"}},"required":["action"],"additionalProperties":false},"schema":{"type":"object","additionalProperties":true}},"required":["name","type"],"additionalProperties":false},"Row":{"type":"object","properties":{"id":{"type":"number","description":"Unique identifier for the row."},"createdAt":{"type":"string","format":"date-time","description":"Timestamp of row creation."},"updatedAt":{"type":"string","format":"date-time","description":"Timestamp of the last row update."},"computed":{"type":"object","additionalProperties":{"type":"object","properties":{"status":{"type":"string"},"error":{"type":"string"},"updatedBy":{"type":"string"},"updatedAt":{"type":"string"}},"required":["status"],"additionalProperties":false}},"stale":{"type":"array","items":{"type":"string"},"description":"[Read-only] List of stale values that are waiting to be recomputed."},"similarity":{"type":"number","description":"Optional numeric value indicating similarity, when using findTableRows."}},"required":["id","computed"],"additionalProperties":true},"File":{"type":"object","properties":{"id":{"type":"string","description":"File ID"},"botId":{"type":"string","description":"The ID of the bot the file belongs to"},"key":{"type":"string","description":"Unique key for the file. Must be unique across the bot (and the integration, when applicable)."},"url":{"type":"string","description":"URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."},"size":{"type":"number","description":"File size in bytes. Non-null if file upload status is \"COMPLETE\".","nullable":true},"contentType":{"type":"string","description":"MIME type of the file's content"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":1000},"description":"The tags of the file as an object of key/value pairs"},"metadata":{"type":"object","additionalProperties":{"nullable":true},"description":"Metadata of the file as an object of key/value pairs. The values can be of any type."},"createdAt":{"type":"string","description":"File creation timestamp in ISO 8601 format"},"updatedAt":{"type":"string","description":"File last update timestamp in ISO 8601 format"},"accessPolicies":{"type":"array","items":{"type":"string","enum":["integrations","public_content"]},"description":"Access policies configured for the file."},"index":{"type":"boolean","description":"Whether the file was requested to be indexed for search or not."},"status":{"type":"string","enum":["upload_pending","upload_failed","upload_completed","indexing_pending","indexing_failed","indexing_completed"],"description":"Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."},"failedStatusReason":{"type":"string","description":"If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."},"expiresAt":{"type":"string","description":"File expiry timestamp in ISO 8601 format"}},"required":["id","botId","key","url","size","contentType","tags","metadata","createdAt","updatedAt","accessPolicies","index","status"],"additionalProperties":false}},"responses":{"createConversationResponse":{"description":"Returns a [Conversation](#schema_conversation) object if creation succeeds. Returns [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"conversation":{"$ref":"#/components/schemas/Conversation"}},"required":["conversation"],"title":"createConversationResponse","additionalProperties":false}}}},"getConversationResponse":{"description":"Returns a [Conversation](#schema_conversation) object if a valid identifier was provided. Returns [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"conversation":{"$ref":"#/components/schemas/Conversation"}},"required":["conversation"],"title":"getConversationResponse","additionalProperties":false}}}},"listConversationsResponse":{"description":"Returns a list of [Conversation](#schema_conversation) objects","content":{"application/json":{"schema":{"type":"object","properties":{"conversations":{"type":"array","items":{"$ref":"#/components/schemas/Conversation"}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["conversations","meta"],"title":"listConversationsResponse","additionalProperties":false}}}},"getOrCreateConversationResponse":{"description":"Returns a [Conversation](#schema_conversation) object if a valid identifier was provided. Returns [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"conversation":{"$ref":"#/components/schemas/Conversation"}},"required":["conversation"],"title":"getOrCreateConversationResponse","additionalProperties":false}}}},"updateConversationResponse":{"description":"Returns an updated [Conversation](#schema_conversation) object if a valid identifier was provided. Returns [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"conversation":{"$ref":"#/components/schemas/Conversation"}},"required":["conversation"],"title":"updateConversationResponse","additionalProperties":false}}}},"deleteConversationResponse":{"description":"Returns the [Conversation](#schema_conversation) object that was deleted","content":{"application/json":{"schema":{"type":"object","title":"deleteConversationResponse","additionalProperties":false}}}},"listParticipantsResponse":{"description":"Returns a list of [Participant](#schema_participant) objects","content":{"application/json":{"schema":{"type":"object","properties":{"participants":{"type":"array","items":{"$ref":"#/components/schemas/User"}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["participants","meta"],"title":"listParticipantsResponse","additionalProperties":false}}}},"addParticipantResponse":{"description":"Returns the [Participant](#schema_participant) object","content":{"application/json":{"schema":{"type":"object","properties":{"participant":{"$ref":"#/components/schemas/User"}},"required":["participant"],"title":"addParticipantResponse","additionalProperties":false}}}},"getParticipantResponse":{"description":"Returns the [Participant](#schema_participant) object","content":{"application/json":{"schema":{"type":"object","properties":{"participant":{"$ref":"#/components/schemas/User"}},"required":["participant"],"title":"getParticipantResponse","additionalProperties":false}}}},"removeParticipantResponse":{"description":"Returns an empty object","content":{"application/json":{"schema":{"type":"object","title":"removeParticipantResponse","additionalProperties":false}}}},"createEventResponse":{"description":"Returns a [Event](#schema_event) object if creation succeeds. Returns [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"event":{"$ref":"#/components/schemas/Event"}},"required":["event"],"title":"createEventResponse","additionalProperties":false}}}},"getEventResponse":{"description":"Returns the [Event](#schema_event) object if a valid identifiers were provided. Returns [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"event":{"$ref":"#/components/schemas/Event"}},"required":["event"],"title":"getEventResponse","additionalProperties":false}}}},"listEventsResponse":{"description":"Returns a list of [Event](#schema_event) objects","content":{"application/json":{"schema":{"type":"object","properties":{"events":{"type":"array","items":{"$ref":"#/components/schemas/Event"}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["events","meta"],"title":"listEventsResponse","additionalProperties":false}}}},"createMessageResponse":{"description":"Returns a [Message](#schema_message) object if creation succeeds.","content":{"application/json":{"schema":{"type":"object","properties":{"message":{"$ref":"#/components/schemas/Message"}},"required":["message"],"title":"createMessageResponse","additionalProperties":false}}}},"getOrCreateMessageResponse":{"description":"Returns a [Message](#schema_message) object if a valid identifier was provided. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"message":{"$ref":"#/components/schemas/Message"}},"required":["message"],"title":"getOrCreateMessageResponse","additionalProperties":false}}}},"getMessageResponse":{"description":"Returns a [Message](#schema_message) object if a valid identifier was provided. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"message":{"$ref":"#/components/schemas/Message"}},"required":["message"],"title":"getMessageResponse","additionalProperties":false}}}},"updateMessageResponse":{"description":"Message information","content":{"application/json":{"schema":{"type":"object","properties":{"message":{"$ref":"#/components/schemas/Message"}},"required":["message"],"title":"updateMessageResponse","additionalProperties":false}}}},"listMessagesResponse":{"description":"Returns a list of [Message](#schema_message) objects.","content":{"application/json":{"schema":{"type":"object","properties":{"messages":{"type":"array","items":{"$ref":"#/components/schemas/Message"}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["messages","meta"],"title":"listMessagesResponse","additionalProperties":false}}}},"deleteMessageResponse":{"description":"Returns the [Message](#schema_message) object that was deleted","content":{"application/json":{"schema":{"type":"object","title":"deleteMessageResponse","additionalProperties":false}}}},"createUserResponse":{"description":"Returns a [User](#schema_user) object if creation succeeds. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"user":{"$ref":"#/components/schemas/User"}},"required":["user"],"title":"createUserResponse","additionalProperties":false}}}},"getUserResponse":{"description":"Returns a [User](#schema_user) object if a valid identifier was provided. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"user":{"$ref":"#/components/schemas/User"}},"required":["user"],"title":"getUserResponse","additionalProperties":false}}}},"listUsersResponse":{"description":"Returns a list of [User](#schema_user) objects","content":{"application/json":{"schema":{"type":"object","properties":{"users":{"type":"array","items":{"$ref":"#/components/schemas/User"}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["users","meta"],"title":"listUsersResponse","additionalProperties":false}}}},"getOrCreateUserResponse":{"description":"Returns a [User](#schema_user) object if a valid identifier was provided. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"user":{"$ref":"#/components/schemas/User"}},"required":["user"],"title":"getOrCreateUserResponse","additionalProperties":false}}}},"updateUserResponse":{"description":"Returns an updated [User](#schema_user) object if a valid identifier was provided. Returns [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"user":{"$ref":"#/components/schemas/User"}},"required":["user"],"title":"updateUserResponse","additionalProperties":false}}}},"deleteUserResponse":{"description":"Returns the [User](#schema_user) object that was deleted","content":{"application/json":{"schema":{"type":"object","title":"deleteUserResponse","additionalProperties":false}}}},"setStateExpiryResponse":{"description":"Returns the updated [State](#schema_state) object if a valid identifier was provided. Returns an [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"state":{"$ref":"#/components/schemas/State"}},"required":["state"],"title":"setStateExpiryResponse","additionalProperties":false}}}},"getStateResponse":{"description":"Returns the [State](#schema_state) object if a valid identifiers were provided. Returns [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"state":{"$ref":"#/components/schemas/State"},"meta":{"type":"object","properties":{"cached":{"type":"boolean"}},"required":["cached"],"additionalProperties":false}},"required":["state","meta"],"title":"getStateResponse","additionalProperties":false}}}},"setStateResponse":{"description":"Returns the updated [State](#schema_state) object if a valid identifier was provided. Returns an [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"state":{"$ref":"#/components/schemas/State"}},"required":["state"],"title":"setStateResponse","additionalProperties":false}}}},"getOrSetStateResponse":{"description":"Returns the [State](#schema_state) object if a valid identifiers were provided. Returns [an error](#errors) otherwise.","content":{"application/json":{"schema":{"type":"object","properties":{"state":{"$ref":"#/components/schemas/State"},"meta":{"type":"object","properties":{"cached":{"type":"boolean"}},"required":["cached"],"additionalProperties":false}},"required":["state","meta"],"title":"getOrSetStateResponse","additionalProperties":false}}}},"patchStateResponse":{"description":"Returns the updated [State](#schema_state) object if a valid identifier was provided. Returns an [an error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"state":{"$ref":"#/components/schemas/State"}},"required":["state"],"title":"patchStateResponse","additionalProperties":false}}}},"callActionResponse":{"description":"Action payload","content":{"application/json":{"schema":{"type":"object","properties":{"output":{"type":"object","additionalProperties":true,"description":"Input of the action"},"meta":{"type":"object","properties":{"cached":{"type":"boolean"}},"required":["cached"],"additionalProperties":false}},"required":["output","meta"],"title":"callActionResponse","additionalProperties":false}}}},"configureIntegrationResponse":{"description":"Configuration of the integration","content":{"application/json":{"schema":{"type":"object","title":"configureIntegrationResponse","additionalProperties":false}}}},"getTaskResponse":{"description":"Returns a [Task](#schema_task) object if a valid identifier was provided. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"task":{"$ref":"#/components/schemas/Task"}},"required":["task"],"title":"getTaskResponse","additionalProperties":false}}}},"createTaskResponse":{"description":"Returns a [Task](#schema_task) object if creation succeeds. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"task":{"$ref":"#/components/schemas/Task"}},"required":["task"],"title":"createTaskResponse","additionalProperties":false}}}},"updateTaskResponse":{"description":"Returns an updated [Task](#schema_task) object if a valid identifier was provided. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"task":{"$ref":"#/components/schemas/Task"}},"required":["task"],"title":"updateTaskResponse","additionalProperties":false}}}},"deleteTaskResponse":{"description":"Returns the [Task](#schema_task) object that was deleted","content":{"application/json":{"schema":{"type":"object","title":"deleteTaskResponse","additionalProperties":false}}}},"listTasksResponse":{"description":"Returns a list of [Task](#schema_task) objects","content":{"application/json":{"schema":{"type":"object","properties":{"tasks":{"type":"array","items":{"$ref":"#/components/schemas/Task"}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["tasks","meta"],"title":"listTasksResponse","additionalProperties":false}}}},"createWorkflowResponse":{"description":"Returns a [Workflow](#schema_workflow) object if creation succeeds. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"workflow":{"$ref":"#/components/schemas/Workflow"}},"required":["workflow"],"title":"createWorkflowResponse","additionalProperties":false}}}},"getWorkflowResponse":{"description":"Returns a [Workflow](#schema_workflow) object if a valid identifier was provided. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"workflow":{"$ref":"#/components/schemas/Workflow"}},"required":["workflow"],"title":"getWorkflowResponse","additionalProperties":false}}}},"updateWorkflowResponse":{"description":"Returns an updated [Workflow](#schema_workflow) object if a valid identifier was provided. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"workflow":{"$ref":"#/components/schemas/Workflow"}},"required":["workflow"],"title":"updateWorkflowResponse","additionalProperties":false}}}},"deleteWorkflowResponse":{"description":"Returns the [Workflow](#schema_workflow) object that was deleted","content":{"application/json":{"schema":{"type":"object","title":"deleteWorkflowResponse","additionalProperties":false}}}},"listWorkflowsResponse":{"description":"Returns a list of [Workflow](#schema_workflow) objects","content":{"application/json":{"schema":{"type":"object","properties":{"workflows":{"type":"array","items":{"$ref":"#/components/schemas/Workflow"}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["workflows","meta"],"title":"listWorkflowsResponse","additionalProperties":false}}}},"getOrCreateWorkflowResponse":{"description":"Returns a [Workflow](#schema_workflow) object if creation succeeds. Returns an [Error](#errors) otherwise","content":{"application/json":{"schema":{"type":"object","properties":{"workflow":{"$ref":"#/components/schemas/Workflow"}},"required":["workflow"],"title":"getOrCreateWorkflowResponse","additionalProperties":false}}}},"listTagValuesResponse":{"description":"Empty response","content":{"application/json":{"schema":{"type":"object","properties":{"tags":{"type":"array","items":{"type":"object","properties":{"value":{"type":"string"}},"required":["value"]}},"meta":{"type":"object","properties":{"nextToken":{"type":"string","description":"The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."}},"additionalProperties":false}},"required":["tags","meta"],"title":"listTagValuesResponse","additionalProperties":false}}}},"trackAnalyticsResponse":{"description":"Success","content":{"application/json":{"schema":{"type":"object","title":"trackAnalyticsResponse","additionalProperties":false}}}}},"requestBodies":{"createConversationBody":{"description":"Conversation data","content":{"application/json":{"schema":{"type":"object","properties":{"channel":{"type":"string","maxLength":200,"description":"Channel name"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Tags for the [Conversation](#schema_conversation)"},"integrationName":{"type":"string","maxLength":200,"description":"[DEPRECATED] To create a conversation from within a bot, call an action of the integration instead.","deprecated":true}},"required":["channel","tags"],"title":"createConversationBody","additionalProperties":false}}}},"getOrCreateConversationBody":{"description":"Conversation data","content":{"application/json":{"schema":{"type":"object","properties":{"channel":{"type":"string","maxLength":200,"description":"Channel name"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Tags for the [Conversation](#schema_conversation)"},"integrationName":{"type":"string","maxLength":200,"description":"[DEPRECATED] To create a conversation from within a bot, call an action of the integration instead.","deprecated":true},"discriminateByTags":{"type":"array","items":{"type":"string","maxLength":500},"description":"Optional list of tag names to use for strict matching when looking up existing conversations. If provided, all specified tags must match exactly for a conversation to be considered a match. For example, with an existing conversation whose tags are {\"foo\": \"a\", \"bar\": \"b\", baz: \"c\"}: Without this parameter, ALL tags must match exactly. With [\"bar\",\"baz\"], all listed tags must match their values, and other tags are not considered."}},"required":["channel","tags"],"title":"getOrCreateConversationBody","additionalProperties":false}}}},"updateConversationBody":{"description":"Conversation data","content":{"application/json":{"schema":{"type":"object","properties":{"currentTaskId":{"type":"string"},"tags":{"type":"object","additionalProperties":{"type":"string"},"description":"Tags for the [Conversation](#schema_conversation)"}},"title":"updateConversationBody","additionalProperties":false}}}},"addParticipantBody":{"description":"Participant data","content":{"application/json":{"schema":{"type":"object","properties":{"userId":{"type":"string","minLength":28,"maxLength":36,"description":"User id"}},"required":["userId"],"title":"addParticipantBody","additionalProperties":false}}}},"createEventBody":{"description":"Event data","content":{"application/json":{"schema":{"type":"object","properties":{"type":{"type":"string","maxLength":200,"description":"Type of the [Event](#schema_event)."},"payload":{"type":"object","additionalProperties":true,"description":"Payload is the content of the event defined by the integration installed on your bot or one of the default events created by our API."},"schedule":{"type":"object","properties":{"dateTime":{"type":"string","maxLength":28,"minLength":24,"description":"When the [Event](#schema_event) will be sent, in the ISO 8601 format"},"delay":{"type":"number","description":"Delay in milliseconds before sending the [Event](#schema_event)"}},"description":"Schedule the Event to be sent at a specific time. Either dateTime or delay must be provided.","additionalProperties":false},"conversationId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Conversation](#schema_conversation) to link the event to."},"userId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [User](#schema_user) to link the event to."},"messageId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Message](#schema_message) to link the event to."}},"required":["type","payload"],"title":"createEventBody","additionalProperties":false}}}},"createMessageBody":{"description":"Message data","content":{"application/json":{"schema":{"type":"object","properties":{"payload":{"type":"object","additionalProperties":true,"description":"Payload is the content type of the message. Accepted payload options: Text, Image, Choice, Dropdown, Card, Carousel, File, Audio, Video, Location"},"userId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [User](#schema_user)"},"conversationId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Conversation](#schema_conversation)"},"type":{"type":"string","maxLength":200,"description":"Type of the [Message](#schema_message) represents the resource type that the message is related to"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Message](#schema_message). The set of [Tags](/docs/developers/concepts/tags) available on a [Message](#schema_message) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."},"schedule":{"type":"object","properties":{"dateTime":{"type":"string","maxLength":28,"minLength":24,"description":"When the [Message](#schema_message) will be sent, in the ISO 8601 format"},"delay":{"type":"number","description":"Delay in milliseconds before sending the [Message](#schema_message)"}},"description":"Schedule the Message to be sent at a specific time. Either dateTime or delay must be provided.","additionalProperties":false}},"required":["payload","userId","conversationId","type","tags"],"title":"createMessageBody","additionalProperties":false}}}},"getOrCreateMessageBody":{"description":"Message data","content":{"application/json":{"schema":{"type":"object","properties":{"payload":{"type":"object","additionalProperties":true,"description":"Payload is the content type of the message. Accepted payload options: Text, Image, Choice, Dropdown, Card, Carousel, File, Audio, Video, Location"},"userId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [User](#schema_user)"},"conversationId":{"type":"string","minLength":28,"maxLength":36,"description":"ID of the [Conversation](#schema_conversation)"},"type":{"type":"string","maxLength":200,"description":"Type of the [Message](#schema_message) represents the resource type that the message is related to"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Message](#schema_message). The set of [Tags](/docs/developers/concepts/tags) available on a [Message](#schema_message) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."},"schedule":{"type":"object","properties":{"dateTime":{"type":"string","maxLength":28,"minLength":24,"description":"When the [Message](#schema_message) will be sent, in the ISO 8601 format"},"delay":{"type":"number","description":"Delay in milliseconds before sending the [Message](#schema_message)"}},"description":"Schedule the Message to be sent at a specific time. Either dateTime or delay must be provided.","additionalProperties":false},"discriminateByTags":{"type":"array","items":{"type":"string","maxLength":500},"description":"Optional list of tag names to use for strict matching when looking up existing messages. If provided, all specified tags must match exactly for a message to be considered a match. For example, with an existing message whose tags are {\"foo\": \"a\", \"bar\": \"b\", baz: \"c\"}: Without this parameter, ALL tags must match exactly. With [\"bar\",\"baz\"], all listed tags must match their values, and other tags are not considered."}},"required":["payload","userId","conversationId","type","tags"],"title":"getOrCreateMessageBody","additionalProperties":false}}}},"updateMessageBody":{"description":"Message data","content":{"application/json":{"schema":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"string"},"description":"Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Conversation](#schema_conversation). The set of [Tags](/docs/developers/concepts/tags) available on a [Conversation](#schema_conversation) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."},"payload":{"type":"object","additionalProperties":true,"description":"Payload is the content type of the message. Accepted payload options: Text, Image, Choice, Dropdown, Card, Carousel, File, Audio, Video, Location"}},"required":["tags"],"title":"updateMessageBody","additionalProperties":false}}}},"createUserBody":{"description":"User data","content":{"application/json":{"schema":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Tags for the [User](#schema_user)"},"integrationName":{"type":"string","maxLength":200,"description":"[DEPRECATED] To create a [User](#schema_user) from within a bot, call an action of the integration instead.","deprecated":true},"name":{"type":"string","maxLength":200,"description":"Name of the user"},"pictureUrl":{"type":"string","maxLength":40000,"description":"URI of the user picture"}},"required":["tags"],"title":"createUserBody","additionalProperties":false}}}},"getOrCreateUserBody":{"description":"User data","content":{"application/json":{"schema":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Tags for the [User](#schema_user)"},"integrationName":{"type":"string","maxLength":200,"description":"[DEPRECATED] To create a [User](#schema_user) from within a bot, call an action of the integration instead.","deprecated":true},"name":{"type":"string","maxLength":200,"description":"Name of the user"},"pictureUrl":{"type":"string","maxLength":40000,"description":"URI of the user picture"},"discriminateByTags":{"type":"array","items":{"type":"string","maxLength":500},"description":"Optional list of tag names to use for strict matching when looking up existing users. If provided, all specified tags must match exactly for a user to be considered a match. For example, with an existing user whose tags are {\"foo\": \"a\", \"bar\": \"b\", baz: \"c\"}: Without this parameter, ALL tags must match exactly. With [\"bar\",\"baz\"], all listed tags must match their values, and other tags are not considered."}},"required":["tags"],"title":"getOrCreateUserBody","additionalProperties":false}}}},"updateUserBody":{"description":"User data","content":{"application/json":{"schema":{"type":"object","properties":{"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Tags for the [User](#schema_user)"},"name":{"type":"string","maxLength":200,"description":"Name of the user"},"pictureUrl":{"type":"string","maxLength":40000,"nullable":true,"description":"URI of the user picture"}},"title":"updateUserBody","additionalProperties":false}}}},"setStateExpiryBody":{"description":"State expiry","content":{"application/json":{"schema":{"type":"object","properties":{"expiry":{"type":"number","minimum":1,"maximum":2592000000,"nullable":true,"description":"Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."}},"required":["expiry"],"title":"setStateExpiryBody","additionalProperties":false}}}},"setStateBody":{"description":"State content","content":{"application/json":{"schema":{"type":"object","properties":{"payload":{"type":"object","additionalProperties":true,"nullable":true,"description":"Payload is the content of the state defined by your bot."},"expiry":{"type":"number","minimum":1,"maximum":2592000000,"nullable":true,"description":"Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."}},"required":["payload"],"title":"setStateBody","additionalProperties":false}}}},"getOrSetStateBody":{"description":"State content","content":{"application/json":{"schema":{"type":"object","properties":{"payload":{"type":"object","additionalProperties":true,"description":"Payload is the content of the state defined by your bot."},"expiry":{"type":"number","minimum":1,"maximum":2592000000,"nullable":true,"description":"Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."}},"required":["payload"],"title":"getOrSetStateBody","additionalProperties":false}}}},"patchStateBody":{"description":"State content","content":{"application/json":{"schema":{"type":"object","properties":{"payload":{"type":"object","additionalProperties":true,"description":"Payload is the content of the state defined by your bot."}},"required":["payload"],"title":"patchStateBody","additionalProperties":false}}}},"callActionBody":{"description":"Action payload","content":{"application/json":{"schema":{"type":"object","properties":{"type":{"type":"string","maxLength":200,"description":"Type of the action"},"input":{"type":"object","additionalProperties":true,"description":"Input of the action"}},"required":["type","input"],"title":"callActionBody","additionalProperties":false}}}},"configureIntegrationBody":{"description":"Configuration of the integration","content":{"application/json":{"schema":{"type":"object","properties":{"identifier":{"type":"string","maxLength":200,"description":"Unique identifier of the integration that was installed on the bot"},"scheduleRegisterCall":{"type":"string","enum":["hourly","daily","weekly","bi-weekly","monthly","bi-monthly","quarterly","yearly"],"description":"Recurring schedule on which `register()` will be called on the integration"},"sandboxIdentifiers":{"type":"object","additionalProperties":{"type":"object","nullable":true,"additionalProperties":false},"nullable":true,"description":"Sandbox identifiers for the integration. Setting this to null will remove all sandbox identifiers. Setting an individual sandbox identifier to null will remove that sandbox identifier. This is an experimental feature meant to be used by specific integrations."}},"title":"configureIntegrationBody","additionalProperties":false}}}},"createTaskBody":{"description":"Task data","content":{"application/json":{"schema":{"type":"object","properties":{"title":{"type":"string","maxLength":2000,"description":"Title describing the task"},"description":{"type":"string","maxLength":20000,"description":"All the notes related to the execution of the current task"},"type":{"type":"string","maxLength":200,"description":"Type of the task"},"data":{"type":"object","additionalProperties":true,"description":"Content related to the task"},"parentTaskId":{"type":"string","description":"Parent task id is the parent task that created this task"},"conversationId":{"type":"string","description":"Conversation id related to this task"},"userId":{"type":"string","description":"Specific user related to this task"},"timeoutAt":{"type":"string","format":"date-time","description":"The timeout date where the task should be failed in the ISO 8601 format"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Tags for the [Task](#schema_task)"}},"required":["type","conversationId"],"title":"createTaskBody","additionalProperties":false}}}},"updateTaskBody":{"description":"Task data","content":{"application/json":{"schema":{"type":"object","properties":{"title":{"type":"string","description":"Title describing the task"},"description":{"type":"string","description":"All the notes related to the execution of the current task"},"data":{"type":"object","additionalProperties":true,"description":"Content related to the task"},"timeoutAt":{"type":"string","format":"date-time","description":"The timeout date where the task should be failed in the ISO 8601 format"},"status":{"type":"string","enum":["pending","in_progress","failed","completed","blocked","paused","timeout","cancelled"],"description":"Status of the task"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Tags for the [Task](#schema_task)"}},"title":"updateTaskBody","additionalProperties":false}}}},"createWorkflowBody":{"description":"Workflow data","content":{"application/json":{"schema":{"type":"object","properties":{"name":{"type":"string","description":"Name of the workflow"},"input":{"type":"object","additionalProperties":true,"description":"Content related to the workflow"},"parentWorkflowId":{"type":"string","description":"Parent workflow id is the parent workflow that created this workflow"},"conversationId":{"type":"string","description":"Conversation id related to this workflow"},"userId":{"type":"string","description":"Specific user related to this workflow"},"timeoutAt":{"type":"string","format":"date-time","description":"The timeout date where the workflow should be failed in the ISO 8601 format"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Tags for the [Workflow](#schema_workflow)"},"status":{"type":"string","enum":["pending","in_progress"]},"eventId":{"type":"string","description":"Event id must be specified if the workflow is created with the status in_progress"}},"required":["name","status"],"title":"createWorkflowBody","additionalProperties":false}}}},"updateWorkflowBody":{"description":"Workflow data","content":{"application/json":{"schema":{"type":"object","properties":{"output":{"type":"object","additionalProperties":true,"description":"Content related to the workflow"},"timeoutAt":{"type":"string","format":"date-time","description":"The timeout date where the workflow should be failed in the ISO 8601 format"},"status":{"type":"string","enum":["completed","cancelled","listening","paused","failed","in_progress"],"description":"Status of the workflow"},"failureReason":{"type":"string","description":"Reason why the workflow failed"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Tags for the [Workflow](#schema_workflow)"},"userId":{"type":"string","description":"Specific user related to this workflow"},"eventId":{"type":"string","description":"Event id must be specified if the workflow is updated with the status in_progress"}},"title":"updateWorkflowBody","additionalProperties":false}}}},"getOrCreateWorkflowBody":{"description":"Workflow data","content":{"application/json":{"schema":{"type":"object","properties":{"name":{"type":"string","description":"Name of the workflow"},"input":{"type":"object","additionalProperties":true,"description":"Content related to the workflow"},"parentWorkflowId":{"type":"string","description":"Parent workflow id is the parent workflow that created this workflow"},"conversationId":{"type":"string","description":"Conversation id related to this workflow"},"userId":{"type":"string","description":"Specific user related to this workflow"},"timeoutAt":{"type":"string","format":"date-time","description":"The timeout date where the workflow should be failed in the ISO 8601 format"},"tags":{"type":"object","additionalProperties":{"type":"string","maxLength":500},"description":"Tags for the [Workflow](#schema_workflow)"},"status":{"type":"string","enum":["pending","in_progress"]},"eventId":{"type":"string","description":"Event id must be specified if the workflow is created with the status in_progress"}},"required":["name","status"],"title":"getOrCreateWorkflowBody","additionalProperties":false}}}},"trackAnalyticsBody":{"description":"Add an event to the analytics","content":{"application/json":{"schema":{"type":"object","properties":{"name":{"type":"string","minLength":1,"maxLength":200},"count":{"type":"integer","minimum":1}},"required":["name","count"],"title":"trackAnalyticsBody","additionalProperties":false}}}}},"parameters":{}}}
+{
+    "openapi": "3.0.0",
+    "servers": [
+        {
+            "url": "https://api.botpress.cloud"
+        }
+    ],
+    "info": {
+        "title": "Botpress API",
+        "description": "API for Botpress Cloud",
+        "version": "1.1.0"
+    },
+    "paths": {
+        "/v1/chat/conversations": {
+            "post": {
+                "operationId": "createConversation",
+                "description": "Creates a new [Conversation](#schema_conversation). When creating a new [Conversation](#schema_conversation), the required tags must be provided. See the specific integration for more details.",
+                "parameters": [],
+                "responses": {
+                    "201": {
+                        "$ref": "#/components/responses/createConversationResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/createConversationResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/createConversationBody"
+                }
+            },
+            "get": {
+                "operationId": "listConversations",
+                "description": "Retrieves a list of [Conversation](#schema_conversation) you’ve previously created. The conversations are returned in sorted order, with the most recent appearing first. The list can be filtered using [Tags](#tags).",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sortField",
+                        "in": "query",
+                        "description": "Sort results by this field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "createdAt",
+                                "updatedAt"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "sortDirection",
+                        "in": "query",
+                        "description": "Sort results in this direction",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Filter by tags",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "participantIds",
+                        "in": "query",
+                        "description": "Filter by participant ids",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "integrationName",
+                        "in": "query",
+                        "description": "Filter by integration name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "channel",
+                        "in": "query",
+                        "description": "Filter by integration channel name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listConversationsResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listConversationsResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/conversations/{id}": {
+            "get": {
+                "operationId": "getConversation",
+                "description": "Retrieves the [Conversation](#schema_conversation) object for a valid identifier.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Conversation id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getConversationResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getConversationResponse"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "updateConversation",
+                "description": "Update a [Conversation](#schema_conversation) object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Conversation id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/updateConversationResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/updateConversationResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/updateConversationBody"
+                }
+            },
+            "delete": {
+                "operationId": "deleteConversation",
+                "description": "Permanently deletes a [Conversation](#schema_conversation). It cannot be undone. Also immediately deletes corresponding [Messages](#schema_message).",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Conversation id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/deleteConversationResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/deleteConversationResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/conversations/get-or-create": {
+            "post": {
+                "operationId": "getOrCreateConversation",
+                "description": "Retrieves the [Conversation](#schema_conversation) object for a valid identifier. If the conversation does not exist, it will be created.",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getOrCreateConversationResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getOrCreateConversationResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/getOrCreateConversationBody"
+                }
+            }
+        },
+        "/v1/chat/conversations/{id}/participants": {
+            "get": {
+                "operationId": "listParticipants",
+                "description": "Retrieves a list of [Participant](#schema_participant) for a given [Conversation](#schema_conversation).",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Conversation id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listParticipantsResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listParticipantsResponse"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "addParticipant",
+                "description": "Add a [Participant](#schema_participant) to a [Conversation](#schema_conversation).",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Conversation id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/addParticipantResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/addParticipantResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/addParticipantBody"
+                }
+            }
+        },
+        "/v1/chat/conversations/{id}/participants/{userId}": {
+            "get": {
+                "operationId": "getParticipant",
+                "description": "Retrieves a [Participant](#schema_participant) from a [Conversation](#schema_conversation).",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Conversation id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "User id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getParticipantResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getParticipantResponse"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "removeParticipant",
+                "description": "Remove a [Participant](#schema_participant) from a [Conversation](#schema_conversation).",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Conversation id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "User id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/removeParticipantResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/removeParticipantResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/events": {
+            "post": {
+                "operationId": "createEvent",
+                "description": "Creates a new [Event](#schema_event). When creating a new [Event](#schema_event), the required tags must be provided. See the specific integration for more details.",
+                "parameters": [],
+                "responses": {
+                    "201": {
+                        "$ref": "#/components/responses/createEventResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/createEventResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/createEventBody"
+                }
+            },
+            "get": {
+                "operationId": "listEvents",
+                "description": "Retrieves a list of [Event](#schema_event) you’ve previously created. The events are returned in sorted order, with the most recent appearing first.",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Filter by event type",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "conversationId",
+                        "in": "query",
+                        "description": "Filter by conversation id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "query",
+                        "description": "Filter by user id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "messageId",
+                        "in": "query",
+                        "description": "Filter by message id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filter by status. Allowed values: pending, ignored, processed, failed.",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "pending",
+                                "ignored",
+                                "processed",
+                                "failed",
+                                "scheduled"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listEventsResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listEventsResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/events/{id}": {
+            "get": {
+                "operationId": "getEvent",
+                "description": "Retrieves the [Event](#schema_event) object for a valid identifiers.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Event id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getEventResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getEventResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/messages": {
+            "post": {
+                "operationId": "createMessage",
+                "description": "Creates a new [Message](#schema_message). When creating a new [Message](#schema_message), the required tags must be provided. See the specific integration for more details.",
+                "parameters": [],
+                "responses": {
+                    "201": {
+                        "$ref": "#/components/responses/createMessageResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/createMessageResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/createMessageBody"
+                }
+            },
+            "get": {
+                "operationId": "listMessages",
+                "description": "Retrieves a list of [Message](#schema_message) you’ve previously created. The messages are returned in sorted order, with the most recent appearing first. The list can be filtered using [Tags](/docs/developers/concepts/tags).",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "conversationId",
+                        "in": "query",
+                        "description": "Conversation id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Filter by tags",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listMessagesResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listMessagesResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/messages/get-or-create": {
+            "post": {
+                "operationId": "getOrCreateMessage",
+                "description": "Retrieves the [Message](#schema_message) object for a valid identifier. If the message does not exist, it will be created.",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getOrCreateMessageResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getOrCreateMessageResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/getOrCreateMessageBody"
+                }
+            }
+        },
+        "/v1/chat/messages/{id}": {
+            "get": {
+                "operationId": "getMessage",
+                "description": "Retrieves the [Message](#schema_message) object for a valid identifier.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Id of the Message",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getMessageResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getMessageResponse"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "updateMessage",
+                "description": "Updates a message tags and payload. The message type cannot be changed. Calling this operation from an integration, to update an incoming message, will not invoke the bot. The other way around it also true; Calling this operation from the bot, to update an outgoing message, will not invoke the integration.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Message id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/updateMessageResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/updateMessageResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/updateMessageBody"
+                }
+            },
+            "delete": {
+                "operationId": "deleteMessage",
+                "description": "Permanently deletes a [Message](#schema_message). It cannot be undone.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Message id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/deleteMessageResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/deleteMessageResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/users": {
+            "post": {
+                "operationId": "createUser",
+                "description": "Creates a new [User](#schema_user). When creating a new [User](#schema_user), the required tags must be provided. See the specific integration for more details.",
+                "parameters": [],
+                "responses": {
+                    "201": {
+                        "$ref": "#/components/responses/createUserResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/createUserResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/createUserBody"
+                }
+            },
+            "get": {
+                "operationId": "listUsers",
+                "description": "Retrieves a list of [User](#schema_user) previously created. The users are returned in sorted order, with the most recent appearing first. The list can be filtered using [Tags](/docs/developers/concepts/tags).",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "conversationId",
+                        "in": "query",
+                        "description": "Filter by conversation id. This will return all users that have participated in the conversation.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Filter by tags",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listUsersResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listUsersResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/users/{id}": {
+            "get": {
+                "operationId": "getUser",
+                "description": "Retrieves the [User](#schema_user) object for a valid identifier.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "User ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getUserResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getUserResponse"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "updateUser",
+                "description": "Update a [User](#schema_user) object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "User ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/updateUserResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/updateUserResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/updateUserBody"
+                }
+            },
+            "delete": {
+                "operationId": "deleteUser",
+                "description": "Permanently deletes a [User](#schema_user). It cannot be undone.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "User ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/deleteUserResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/deleteUserResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/users/get-or-create": {
+            "post": {
+                "operationId": "getOrCreateUser",
+                "description": "Retrieves the [User](#schema_user) object for a valid identifier. If the user does not exist, it will be created.",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getOrCreateUserResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getOrCreateUserResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/getOrCreateUserBody"
+                }
+            }
+        },
+        "/v1/chat/states/{type}/{id}/{name}/expiry": {
+            "post": {
+                "operationId": "setStateExpiry",
+                "description": "Updates the [State](#schema_state) expiry.",
+                "parameters": [
+                    {
+                        "name": "type",
+                        "in": "path",
+                        "description": "State type",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "conversation",
+                                "user",
+                                "bot",
+                                "integration",
+                                "task",
+                                "workflow"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "State id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "description": "State name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/setStateExpiryResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/setStateExpiryResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/setStateExpiryBody"
+                }
+            }
+        },
+        "/v1/chat/states/{type}/{id}/{name}": {
+            "get": {
+                "operationId": "getState",
+                "description": "Retrieves the [State](#schema_state) object for a valid identifiers.",
+                "parameters": [
+                    {
+                        "name": "type",
+                        "in": "path",
+                        "description": "State type",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "conversation",
+                                "user",
+                                "bot",
+                                "integration",
+                                "task",
+                                "workflow"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "State id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "description": "State name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getStateResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getStateResponse"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "setState",
+                "description": "Overrides the [State](#schema_state) object by setting the values of the parameters passed.",
+                "parameters": [
+                    {
+                        "name": "type",
+                        "in": "path",
+                        "description": "State type",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "conversation",
+                                "user",
+                                "bot",
+                                "integration",
+                                "task",
+                                "workflow"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "State id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "description": "State name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/setStateResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/setStateResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/setStateBody"
+                }
+            },
+            "patch": {
+                "operationId": "patchState",
+                "description": "Updates the [State](#schema_state) object by setting the values of the parameters passed.",
+                "parameters": [
+                    {
+                        "name": "type",
+                        "in": "path",
+                        "description": "State type",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "conversation",
+                                "user",
+                                "bot",
+                                "integration",
+                                "task",
+                                "workflow"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "State id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "description": "State name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/patchStateResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/patchStateResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/patchStateBody"
+                }
+            }
+        },
+        "/v1/chat/states/{type}/{id}/{name}/get-or-set": {
+            "post": {
+                "operationId": "getOrSetState",
+                "description": "Retrieves the [State](#schema_state) object for a valid identifiers. If the state does not exist, it creates a new state.",
+                "parameters": [
+                    {
+                        "name": "type",
+                        "in": "path",
+                        "description": "State type",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "conversation",
+                                "user",
+                                "bot",
+                                "integration",
+                                "task",
+                                "workflow"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "State id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "description": "State name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getOrSetStateResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getOrSetStateResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/getOrSetStateBody"
+                }
+            }
+        },
+        "/v1/chat/actions": {
+            "post": {
+                "operationId": "callAction",
+                "description": "Call an action",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/callActionResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/callActionResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/callActionBody"
+                }
+            }
+        },
+        "/v1/chat/integrations/configure": {
+            "post": {
+                "operationId": "configureIntegration",
+                "description": "An integration can call this endpoint to configure itself",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/configureIntegrationResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/configureIntegrationResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/configureIntegrationBody"
+                }
+            }
+        },
+        "/v1/chat/tasks/{id}": {
+            "get": {
+                "operationId": "getTask",
+                "description": "Retrieves the [Task](#schema_task) object for a valid identifier.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Task id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getTaskResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getTaskResponse"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "updateTask",
+                "description": "Update a [Task](#schema_task) object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Task id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/updateTaskResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/updateTaskResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/updateTaskBody"
+                }
+            },
+            "delete": {
+                "operationId": "deleteTask",
+                "description": "Permanently deletes a [Task](#schema_task). It cannot be undone.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Task id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/deleteTaskResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/deleteTaskResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/tasks": {
+            "post": {
+                "operationId": "createTask",
+                "description": "Creates a new [Task](#schema_task). When creating a new [Task](#schema_task), the required tags must be provided. See the specific integration for more details.",
+                "parameters": [],
+                "responses": {
+                    "201": {
+                        "$ref": "#/components/responses/createTaskResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/createTaskResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/createTaskBody"
+                }
+            },
+            "get": {
+                "operationId": "listTasks",
+                "description": "Retrieves a list of [Task](#schema_task) you've previously created. The tasks are returned in sorted order, with the most recent appearing first. The list can be filtered using [Tags](/docs/developers/concepts/tags).",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Filter by tags",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "conversationId",
+                        "in": "query",
+                        "description": "Conversation id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "query",
+                        "description": "User id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "parentTaskId",
+                        "in": "query",
+                        "description": "Parent task id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Status",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "pending",
+                                    "in_progress",
+                                    "failed",
+                                    "completed",
+                                    "blocked",
+                                    "paused",
+                                    "timeout",
+                                    "cancelled"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Type",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listTasksResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listTasksResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/workflows": {
+            "post": {
+                "operationId": "createWorkflow",
+                "description": "Creates a new [Workflow](#schema_workflow).",
+                "parameters": [],
+                "responses": {
+                    "201": {
+                        "$ref": "#/components/responses/createWorkflowResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/createWorkflowResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/createWorkflowBody"
+                }
+            },
+            "get": {
+                "operationId": "listWorkflows",
+                "description": "Retrieves a list of [Workflow](#schema_workflow) you've previously created. The workflows are returned in sorted order, with the most recent appearing first. The list can be filtered using [Tags](/docs/developers/concepts/tags).",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Filter by tags",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "conversationId",
+                        "in": "query",
+                        "description": "Conversation id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "query",
+                        "description": "User id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "parentWorkflowId",
+                        "in": "query",
+                        "description": "Parent workflow id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "statuses",
+                        "in": "query",
+                        "description": "Status",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "pending",
+                                    "in_progress",
+                                    "failed",
+                                    "completed",
+                                    "listening",
+                                    "paused",
+                                    "timedout",
+                                    "cancelled"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "Workflow name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listWorkflowsResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listWorkflowsResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/workflows/{id}": {
+            "get": {
+                "operationId": "getWorkflow",
+                "description": "Retrieves the [Workflow](#schema_workflow) object for a valid identifier.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Workflow id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getWorkflowResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getWorkflowResponse"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "updateWorkflow",
+                "description": "Update a [Workflow](#schema_workflow) object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Workflow id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/updateWorkflowResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/updateWorkflowResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/updateWorkflowBody"
+                }
+            },
+            "delete": {
+                "operationId": "deleteWorkflow",
+                "description": "Permanently deletes a [Workflow](#schema_workflow). It cannot be undone.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Workflow id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/deleteWorkflowResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/deleteWorkflowResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/workflows/get-or-create": {
+            "post": {
+                "operationId": "getOrCreateWorkflow",
+                "description": "Get a workflow by tags or creates a new [Workflow](#schema_workflow) if it doesn't exists.",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/getOrCreateWorkflowResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/getOrCreateWorkflowResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/getOrCreateWorkflowBody"
+                }
+            }
+        },
+        "/v1/chat/tags/{key}/values": {
+            "get": {
+                "operationId": "listTagValues",
+                "description": "Get a bot tag values",
+                "parameters": [
+                    {
+                        "name": "nextToken",
+                        "in": "query",
+                        "description": "Provide the `meta.nextToken` value provided in the last API response to retrieve the next page of results",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "key",
+                        "in": "path",
+                        "description": "Tag key",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Tag type",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "user",
+                                "conversation",
+                                "message"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/listTagValuesResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/listTagValuesResponse"
+                    }
+                }
+            }
+        },
+        "/v1/chat/analytics": {
+            "post": {
+                "operationId": "trackAnalytics",
+                "description": "Add an event to the analytics",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/trackAnalyticsResponse"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/trackAnalyticsResponse"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/trackAnalyticsBody"
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "BearerAuth": {
+                "type": "http",
+                "scheme": "bearer"
+            },
+            "BotIdHeader": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "x-bot-id",
+                "description": "Your bot ID."
+            }
+        },
+        "schemas": {
+            "Bot": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [Bot](#schema_bot)"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [Bot](#schema_bot) in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updating date of the [Bot](#schema_bot) in ISO 8601 format"
+                    },
+                    "signingSecret": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "description": "Signing secret of the [Bot](#schema_bot)"
+                    },
+                    "integrations": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Name of the [Integration](#schema_integration)"
+                                },
+                                "version": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Version of the [Integration](#schema_integration)"
+                                },
+                                "webhookUrl": {
+                                    "type": "string",
+                                    "maxLength": 2000
+                                },
+                                "webhookId": {
+                                    "type": "string",
+                                    "maxLength": 200
+                                },
+                                "identifier": {
+                                    "type": "string",
+                                    "maxLength": 2000
+                                },
+                                "configurationType": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "nullable": true
+                                },
+                                "configuration": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "enum": [
+                                        "registration_pending",
+                                        "registered",
+                                        "registration_failed",
+                                        "unregistration_pending",
+                                        "unregistered",
+                                        "unregistration_failed"
+                                    ]
+                                },
+                                "statusReason": {
+                                    "type": "string",
+                                    "maxLength": 2000,
+                                    "nullable": true
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "minLength": 28,
+                                    "maxLength": 36,
+                                    "description": "ID of the [Integration](#schema_integration)"
+                                },
+                                "createdAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Creation date of the [Integration](#schema_integration) in ISO 8601 format"
+                                },
+                                "updatedAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Updating date of the [Integration](#schema_integration) in ISO 8601 format"
+                                },
+                                "title": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 64,
+                                    "description": "Title of the integration. This is the name that will be displayed in the UI"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the integration. This is the description that will be displayed in the UI"
+                                },
+                                "iconUrl": {
+                                    "type": "string",
+                                    "description": "URL of the icon of the integration. This is the icon that will be displayed in the UI"
+                                },
+                                "public": {
+                                    "type": "boolean",
+                                    "description": "Idicates if the integration is public. Public integrations are available to all and cannot be updated without creating a new version."
+                                },
+                                "verificationStatus": {
+                                    "type": "string",
+                                    "enum": [
+                                        "unapproved",
+                                        "pending",
+                                        "approved",
+                                        "rejected"
+                                    ],
+                                    "description": "Status of the integration version verification"
+                                }
+                            },
+                            "required": [
+                                "enabled",
+                                "name",
+                                "version",
+                                "webhookUrl",
+                                "webhookId",
+                                "configurationType",
+                                "configuration",
+                                "status",
+                                "statusReason",
+                                "id",
+                                "createdAt",
+                                "updatedAt",
+                                "title",
+                                "description",
+                                "iconUrl",
+                                "public",
+                                "verificationStatus"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "description": "A mapping of integrations to their configuration"
+                    },
+                    "user": {
+                        "type": "object",
+                        "properties": {
+                            "tags": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "maxLength": 64,
+                                            "description": "Title of the tag"
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "maxLength": 256,
+                                            "description": "Description of the tag"
+                                        }
+                                    },
+                                    "description": "Definition of a tag that can be provided on the object",
+                                    "additionalProperties": false
+                                }
+                            }
+                        },
+                        "required": [
+                            "tags"
+                        ],
+                        "description": "User object configuration",
+                        "additionalProperties": false
+                    },
+                    "conversation": {
+                        "type": "object",
+                        "properties": {
+                            "tags": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "maxLength": 64,
+                                            "description": "Title of the tag"
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "maxLength": 256,
+                                            "description": "Description of the tag"
+                                        }
+                                    },
+                                    "description": "Definition of a tag that can be provided on the object",
+                                    "additionalProperties": false
+                                }
+                            }
+                        },
+                        "required": [
+                            "tags"
+                        ],
+                        "description": "Conversation object configuration",
+                        "additionalProperties": false
+                    },
+                    "message": {
+                        "type": "object",
+                        "properties": {
+                            "tags": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "maxLength": 64,
+                                            "description": "Title of the tag"
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "maxLength": 256,
+                                            "description": "Description of the tag"
+                                        }
+                                    },
+                                    "description": "Definition of a tag that can be provided on the object",
+                                    "additionalProperties": false
+                                }
+                            }
+                        },
+                        "required": [
+                            "tags"
+                        ],
+                        "description": "Message object configuration",
+                        "additionalProperties": false
+                    },
+                    "states": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "conversation",
+                                        "user",
+                                        "bot",
+                                        "task"
+                                    ],
+                                    "description": "Type of the [State](#schema_state) (`conversation`, `user`, `bot` or `task`)"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Schema of the [State](#schema_state) in the `JSON schema` format. This `JSON schema` is going to be used for validating the state data."
+                                },
+                                "expiry": {
+                                    "type": "number",
+                                    "minimum": 1,
+                                    "description": "Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "schema"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "description": "A mapping of states to their definition"
+                    },
+                    "configuration": {
+                        "type": "object",
+                        "properties": {
+                            "data": {
+                                "type": "object",
+                                "additionalProperties": true,
+                                "description": "Configuration data"
+                            },
+                            "schema": {
+                                "type": "object",
+                                "additionalProperties": true,
+                                "description": "Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."
+                            }
+                        },
+                        "required": [
+                            "data",
+                            "schema"
+                        ],
+                        "description": "Configuration of the bot",
+                        "additionalProperties": false
+                    },
+                    "events": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the event"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the event"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            },
+                            "required": [
+                                "schema"
+                            ],
+                            "description": "Event Definition",
+                            "additionalProperties": false
+                        },
+                        "description": "Events definition"
+                    },
+                    "recurringEvents": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "schedule": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cron": {
+                                            "type": "string",
+                                            "maxLength": 200
+                                        }
+                                    },
+                                    "required": [
+                                        "cron"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "maxLength": 200
+                                },
+                                "payload": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                },
+                                "failedAttempts": {
+                                    "type": "number",
+                                    "description": "The number of times the recurring event failed to run. This counter resets once the recurring event runs successfully."
+                                },
+                                "lastFailureReason": {
+                                    "type": "string",
+                                    "maxLength": 2000,
+                                    "description": "The reason why the recurring event failed to run in the last attempt.",
+                                    "nullable": true
+                                }
+                            },
+                            "required": [
+                                "schedule",
+                                "type",
+                                "payload",
+                                "failedAttempts",
+                                "lastFailureReason"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "description": "Recurring events"
+                    },
+                    "subscriptions": {
+                        "type": "object",
+                        "properties": {
+                            "events": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "nullable": true,
+                                "description": "Events that the bot is currently subscribed on (ex: \"slack:reactionAdded\"). If null, the bot is subscribed to all events."
+                            }
+                        },
+                        "required": [
+                            "events"
+                        ],
+                        "description": "Subscriptions of the bot",
+                        "additionalProperties": false
+                    },
+                    "actions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the action"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the action"
+                                },
+                                "billable": {
+                                    "type": "boolean"
+                                },
+                                "cacheable": {
+                                    "type": "boolean"
+                                },
+                                "input": {
+                                    "type": "object",
+                                    "properties": {
+                                        "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    },
+                                    "required": [
+                                        "schema"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "output": {
+                                    "type": "object",
+                                    "properties": {
+                                        "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    },
+                                    "required": [
+                                        "schema"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "input",
+                                "output"
+                            ],
+                            "description": "Action definition",
+                            "additionalProperties": false
+                        },
+                        "description": "Actions definition"
+                    },
+                    "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Tags of [Bot](#schema_bot)"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the [Bot](#schema_bot)"
+                    },
+                    "deployedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Last deployment date of the [Bot](#schema_bot) in the ISO 8601 format"
+                    },
+                    "dev": {
+                        "type": "boolean",
+                        "description": "Indicates if the [Bot](#schema_bot) is a development bot; Development bots run locally and can install dev integrations"
+                    },
+                    "createdBy": {
+                        "type": "string",
+                        "description": "Id of the user that created the bot"
+                    },
+                    "alwaysAlive": {
+                        "type": "boolean",
+                        "description": "Indicates if the [Bot](#schema_bot) should be in always alive mode"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "active",
+                            "deploying"
+                        ],
+                        "description": "Status of the bot"
+                    },
+                    "medias": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "url": {
+                                    "type": "string",
+                                    "description": "URL of the media file"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the media file"
+                                }
+                            },
+                            "required": [
+                                "url",
+                                "name"
+                            ]
+                        },
+                        "description": "Media files associated with the [Bot](#schema_bot)"
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt",
+                    "signingSecret",
+                    "integrations",
+                    "user",
+                    "conversation",
+                    "message",
+                    "states",
+                    "configuration",
+                    "events",
+                    "recurringEvents",
+                    "subscriptions",
+                    "actions",
+                    "tags",
+                    "name",
+                    "dev",
+                    "alwaysAlive",
+                    "status",
+                    "medias"
+                ],
+                "additionalProperties": false
+            },
+            "Integration": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "ID of the [Integration](#schema_integration)"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [Integration](#schema_integration) in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updating date of the [Integration](#schema_integration) in ISO 8601 format"
+                    },
+                    "identifier": {
+                        "type": "object",
+                        "properties": {
+                            "fallbackHandlerScript": {
+                                "type": "string",
+                                "maxLength": 2000,
+                                "description": "VRL Script of the [Integration](#schema_integration) to handle incoming requests for a request that doesn't have an identifier"
+                            },
+                            "extractScript": {
+                                "type": "string",
+                                "maxLength": 2000,
+                                "description": "VRL Script of the [Integration](#schema_integration) to extract the identifier from an incoming webhook often use for OAuth"
+                            }
+                        },
+                        "description": "Global identifier configuration of the [Integration](#schema_integration)",
+                        "additionalProperties": false
+                    },
+                    "sandbox": {
+                        "type": "object",
+                        "properties": {
+                            "identifierExtractScript": {
+                                "type": "string",
+                                "maxLength": 2000,
+                                "description": "VRL Script of the [Integration](#schema_integration) to extract the identifier from an incoming webhook used specifically for the sandbox"
+                            },
+                            "messageExtractScript": {
+                                "type": "string",
+                                "maxLength": 2000,
+                                "description": "VRL Script of the [Integration](#schema_integration) to extract the message from an incoming webhook used specifically for the sandbox"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "url": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "description": "URL of the [Integration](#schema_integration)"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Name of the [Integration](#schema_integration)"
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Version of the [Integration](#schema_integration)"
+                    },
+                    "interfaces": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "minLength": 28,
+                                    "maxLength": 36,
+                                    "description": "ID of the interface"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Name of the interface"
+                                },
+                                "version": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Version of the interface"
+                                },
+                                "entities": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "maxLength": 200
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "actions": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "maxLength": 200
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "events": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "maxLength": 200
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "channels": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "maxLength": 200
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "additionalProperties": false
+                                    }
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name",
+                                "version",
+                                "entities",
+                                "actions",
+                                "events",
+                                "channels"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "configuration": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string",
+                                "maxLength": 64,
+                                "description": "Title of the configuration"
+                            },
+                            "description": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "description": "Description of the configuration"
+                            },
+                            "identifier": {
+                                "type": "object",
+                                "properties": {
+                                    "linkTemplateScript": {
+                                        "type": "string",
+                                        "maxLength": 2000
+                                    },
+                                    "required": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "required"
+                                ],
+                                "description": "Identifier configuration of the [Integration](#schema_integration)",
+                                "additionalProperties": false
+                            },
+                            "schema": {
+                                "type": "object",
+                                "additionalProperties": true,
+                                "description": "Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."
+                            }
+                        },
+                        "required": [
+                            "identifier",
+                            "schema"
+                        ],
+                        "description": "Configuration definition",
+                        "additionalProperties": false
+                    },
+                    "configurations": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the configuration"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the configuration"
+                                },
+                                "identifier": {
+                                    "type": "object",
+                                    "properties": {
+                                        "linkTemplateScript": {
+                                            "type": "string",
+                                            "maxLength": 2000
+                                        },
+                                        "required": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "required"
+                                    ],
+                                    "description": "Identifier configuration of the [Integration](#schema_integration)",
+                                    "additionalProperties": false
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."
+                                }
+                            },
+                            "required": [
+                                "identifier",
+                                "schema"
+                            ],
+                            "description": "Configuration definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "channels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the channel"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the channel"
+                                },
+                                "messages": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "schema": {
+                                                "type": "object",
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "required": [
+                                            "schema"
+                                        ],
+                                        "description": "Message definition",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "conversation": {
+                                    "type": "object",
+                                    "properties": {
+                                        "tags": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "title": {
+                                                        "type": "string",
+                                                        "maxLength": 64,
+                                                        "description": "Title of the tag"
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "maxLength": 256,
+                                                        "description": "Description of the tag"
+                                                    }
+                                                },
+                                                "description": "Definition of a tag that can be provided on the object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "creation": {
+                                            "type": "object",
+                                            "properties": {
+                                                "enabled": {
+                                                    "type": "boolean",
+                                                    "description": "Enable conversation creation"
+                                                },
+                                                "requiredTags": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "The list of tags that are required to be specified when calling the API directly to create a conversation."
+                                                }
+                                            },
+                                            "required": [
+                                                "enabled",
+                                                "requiredTags"
+                                            ],
+                                            "description": "The conversation creation setting determines how to create a conversation through the API directly. The integration will have to implement the `createConversation` functionality to support this setting.",
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "tags",
+                                        "creation"
+                                    ],
+                                    "description": "Conversation object configuration",
+                                    "additionalProperties": false
+                                },
+                                "message": {
+                                    "type": "object",
+                                    "properties": {
+                                        "tags": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "title": {
+                                                        "type": "string",
+                                                        "maxLength": 64,
+                                                        "description": "Title of the tag"
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "maxLength": 256,
+                                                        "description": "Description of the tag"
+                                                    }
+                                                },
+                                                "description": "Definition of a tag that can be provided on the object",
+                                                "additionalProperties": false
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "tags"
+                                    ],
+                                    "description": "Message object configuration",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "messages",
+                                "conversation",
+                                "message"
+                            ],
+                            "description": "Channel definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "states": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "conversation",
+                                        "user",
+                                        "integration"
+                                    ],
+                                    "description": "Type of the [State](#schema_state) (`conversation`, `user` or `integration`)"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Schema of the [State](#schema_state) in the `JSON schema` format. This `JSON schema` is going to be used for validating the state data."
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "schema"
+                            ],
+                            "description": "State definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "events": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the event"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the event"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            },
+                            "required": [
+                                "schema"
+                            ],
+                            "description": "Event Definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "actions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the action"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the action"
+                                },
+                                "billable": {
+                                    "type": "boolean"
+                                },
+                                "cacheable": {
+                                    "type": "boolean"
+                                },
+                                "input": {
+                                    "type": "object",
+                                    "properties": {
+                                        "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    },
+                                    "required": [
+                                        "schema"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "output": {
+                                    "type": "object",
+                                    "properties": {
+                                        "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    },
+                                    "required": [
+                                        "schema"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "input",
+                                "output"
+                            ],
+                            "description": "Action definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "user": {
+                        "type": "object",
+                        "properties": {
+                            "tags": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "maxLength": 64,
+                                            "description": "Title of the tag"
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "maxLength": 256,
+                                            "description": "Description of the tag"
+                                        }
+                                    },
+                                    "description": "Definition of a tag that can be provided on the object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "creation": {
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean",
+                                        "description": "Enable user creation"
+                                    },
+                                    "requiredTags": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "The list of tags that are required to be specified when calling the API directly to create a user."
+                                    }
+                                },
+                                "required": [
+                                    "enabled",
+                                    "requiredTags"
+                                ],
+                                "description": "The user creation setting determines how to create a user through the API directly. The integration will have to implement the `createUser` functionality to support this setting.",
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "tags",
+                            "creation"
+                        ],
+                        "description": "User object configuration",
+                        "additionalProperties": false
+                    },
+                    "entities": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the entity"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the entity"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            },
+                            "required": [
+                                "schema"
+                            ],
+                            "description": "Entity definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "dev": {
+                        "type": "boolean",
+                        "description": "Indicates if the integration is a development integration; Dev integrations run locally"
+                    },
+                    "title": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 64,
+                        "description": "Title of the integration. This is the name that will be displayed in the UI"
+                    },
+                    "description": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "description": "Description of the integration. This is the description that will be displayed in the UI"
+                    },
+                    "iconUrl": {
+                        "type": "string",
+                        "description": "URL of the icon of the integration. This is the icon that will be displayed in the UI"
+                    },
+                    "readmeUrl": {
+                        "type": "string",
+                        "description": "URL of the readme of the integration. This is the readme that will be displayed in the UI"
+                    },
+                    "public": {
+                        "type": "boolean",
+                        "description": "Idicates if the integration is public. Public integrations are available to all and cannot be updated without creating a new version."
+                    },
+                    "verificationStatus": {
+                        "type": "string",
+                        "enum": [
+                            "unapproved",
+                            "pending",
+                            "approved",
+                            "rejected"
+                        ],
+                        "description": "Status of the integration version verification"
+                    },
+                    "secrets": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Secrets are integration-wide values available in the code via environment variables formatted with a SECRET_ prefix followed by your secret name. A secret name must respect SCREAMING_SNAKE casing."
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt",
+                    "identifier",
+                    "url",
+                    "name",
+                    "version",
+                    "interfaces",
+                    "configuration",
+                    "configurations",
+                    "channels",
+                    "states",
+                    "events",
+                    "actions",
+                    "user",
+                    "entities",
+                    "dev",
+                    "title",
+                    "description",
+                    "iconUrl",
+                    "readmeUrl",
+                    "public",
+                    "verificationStatus",
+                    "secrets"
+                ],
+                "additionalProperties": false
+            },
+            "Interface": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "ID of the [Interface](#schema_interface)"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [Interface](#schema_interface) in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updating date of the [Interface](#schema_interface) in ISO 8601 format"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Name of the [Interface](#schema_interface)"
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Version of the [Interface](#schema_interface)"
+                    },
+                    "entities": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the entity"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the entity"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            },
+                            "required": [
+                                "schema"
+                            ],
+                            "description": "Entity definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "events": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the event"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the event"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            },
+                            "required": [
+                                "schema"
+                            ],
+                            "description": "Event Definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "actions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the action"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the action"
+                                },
+                                "billable": {
+                                    "type": "boolean"
+                                },
+                                "cacheable": {
+                                    "type": "boolean"
+                                },
+                                "input": {
+                                    "type": "object",
+                                    "properties": {
+                                        "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    },
+                                    "required": [
+                                        "schema"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "output": {
+                                    "type": "object",
+                                    "properties": {
+                                        "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    },
+                                    "required": [
+                                        "schema"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "input",
+                                "output"
+                            ],
+                            "description": "Action definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "channels": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the channel"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the channel"
+                                },
+                                "messages": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "schema": {
+                                                "type": "object",
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "required": [
+                                            "schema"
+                                        ],
+                                        "description": "Message definition",
+                                        "additionalProperties": false
+                                    }
+                                }
+                            },
+                            "required": [
+                                "messages"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "nameTemplate": {
+                        "type": "object",
+                        "properties": {
+                            "script": {
+                                "type": "string",
+                                "maxLength": 2000
+                            },
+                            "language": {
+                                "type": "string",
+                                "maxLength": 200
+                            }
+                        },
+                        "required": [
+                            "script",
+                            "language"
+                        ],
+                        "description": "Template string optionaly used at build time by integrations implementing this interface to pick a name for actions and events.",
+                        "additionalProperties": false
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt",
+                    "name",
+                    "version",
+                    "entities",
+                    "events",
+                    "actions",
+                    "channels"
+                ],
+                "additionalProperties": false
+            },
+            "Plugin": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "ID of the [Plugin](#schema_plugin)"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Name of the [Plugin](#schema_plugin)"
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Version of the [Plugin](#schema_plugin)"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [Plugin](#schema_plugin) in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updating date of the [Plugin](#schema_plugin) in ISO 8601 format"
+                    },
+                    "configuration": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string",
+                                "maxLength": 64,
+                                "description": "Title of the configuration"
+                            },
+                            "description": {
+                                "type": "string",
+                                "maxLength": 256,
+                                "description": "Description of the configuration"
+                            },
+                            "schema": {
+                                "type": "object",
+                                "additionalProperties": true,
+                                "description": "Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."
+                            }
+                        },
+                        "required": [
+                            "schema"
+                        ],
+                        "description": "Configuration definition",
+                        "additionalProperties": false
+                    },
+                    "states": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "conversation",
+                                        "user",
+                                        "bot",
+                                        "task"
+                                    ],
+                                    "description": "Type of the [State](#schema_state) (`conversation`, `user`, `bot` or `task`)"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Schema of the [State](#schema_state) in the `JSON schema` format. This `JSON schema` is going to be used for validating the state data."
+                                },
+                                "expiry": {
+                                    "type": "number",
+                                    "minimum": 1,
+                                    "description": "Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "schema"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "events": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the event"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the event"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            },
+                            "required": [
+                                "schema"
+                            ],
+                            "description": "Event Definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "actions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "description": "Title of the action"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 256,
+                                    "description": "Description of the action"
+                                },
+                                "billable": {
+                                    "type": "boolean"
+                                },
+                                "cacheable": {
+                                    "type": "boolean"
+                                },
+                                "input": {
+                                    "type": "object",
+                                    "properties": {
+                                        "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    },
+                                    "required": [
+                                        "schema"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "output": {
+                                    "type": "object",
+                                    "properties": {
+                                        "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    },
+                                    "required": [
+                                        "schema"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "input",
+                                "output"
+                            ],
+                            "description": "Action definition",
+                            "additionalProperties": false
+                        }
+                    },
+                    "dependencies": {
+                        "type": "object",
+                        "properties": {
+                            "interfaces": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "minLength": 28,
+                                            "maxLength": 36
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "maxLength": 200
+                                        },
+                                        "version": {
+                                            "type": "string",
+                                            "maxLength": 200
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "name",
+                                        "version"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "integrations": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "minLength": 28,
+                                            "maxLength": 36
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "maxLength": 200
+                                        },
+                                        "version": {
+                                            "type": "string",
+                                            "maxLength": 200
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "name",
+                                        "version"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            }
+                        },
+                        "required": [
+                            "interfaces",
+                            "integrations"
+                        ],
+                        "additionalProperties": false
+                    },
+                    "user": {
+                        "type": "object",
+                        "properties": {
+                            "tags": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "maxLength": 64,
+                                            "description": "Title of the tag"
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "maxLength": 256,
+                                            "description": "Description of the tag"
+                                        }
+                                    },
+                                    "description": "Definition of a tag that can be provided on the object",
+                                    "additionalProperties": false
+                                }
+                            }
+                        },
+                        "required": [
+                            "tags"
+                        ],
+                        "description": "User object configuration",
+                        "additionalProperties": false
+                    },
+                    "conversation": {
+                        "type": "object",
+                        "properties": {
+                            "tags": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "maxLength": 64,
+                                            "description": "Title of the tag"
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "maxLength": 256,
+                                            "description": "Description of the tag"
+                                        }
+                                    },
+                                    "description": "Definition of a tag that can be provided on the object",
+                                    "additionalProperties": false
+                                }
+                            }
+                        },
+                        "required": [
+                            "tags"
+                        ],
+                        "description": "Conversation object configuration",
+                        "additionalProperties": false
+                    },
+                    "title": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 64,
+                        "description": "Title of the plugin. This is the name that will be displayed in the UI"
+                    },
+                    "description": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "description": "Description of the plugin. This is the description that will be displayed in the UI"
+                    },
+                    "iconUrl": {
+                        "type": "string",
+                        "description": "URL of the icon of the plugin. This is the icon that will be displayed in the UI"
+                    },
+                    "readmeUrl": {
+                        "type": "string",
+                        "description": "URL of the readme of the plugin. This is the readme that will be displayed in the UI"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "version",
+                    "createdAt",
+                    "updatedAt",
+                    "configuration",
+                    "states",
+                    "events",
+                    "actions",
+                    "dependencies",
+                    "user",
+                    "conversation",
+                    "title",
+                    "description",
+                    "iconUrl",
+                    "readmeUrl"
+                ],
+                "additionalProperties": false
+            },
+            "Workspace": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "ownerId": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    },
+                    "botCount": {
+                        "type": "number"
+                    },
+                    "billingVersion": {
+                        "type": "string",
+                        "enum": [
+                            "v1",
+                            "v2",
+                            "v3"
+                        ]
+                    },
+                    "plan": {
+                        "type": "string",
+                        "enum": [
+                            "community",
+                            "team",
+                            "enterprise",
+                            "plus"
+                        ]
+                    },
+                    "blocked": {
+                        "type": "boolean"
+                    },
+                    "spendingLimit": {
+                        "type": "number"
+                    },
+                    "about": {
+                        "default": "",
+                        "type": "string"
+                    },
+                    "profilePicture": {
+                        "default": "",
+                        "type": "string"
+                    },
+                    "contactEmail": {
+                        "default": "",
+                        "type": "string"
+                    },
+                    "website": {
+                        "default": "",
+                        "type": "string"
+                    },
+                    "socialAccounts": {
+                        "default": [],
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "isPublic": {
+                        "type": "boolean"
+                    },
+                    "handle": {
+                        "default": "",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "ownerId",
+                    "createdAt",
+                    "updatedAt",
+                    "botCount",
+                    "billingVersion",
+                    "plan",
+                    "blocked",
+                    "spendingLimit"
+                ],
+                "additionalProperties": false
+            },
+            "WorkspaceMember": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "userId": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "role": {
+                        "type": "string",
+                        "enum": [
+                            "viewer",
+                            "billing",
+                            "developer",
+                            "manager",
+                            "administrator",
+                            "owner"
+                        ]
+                    },
+                    "profilePicture": {
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "type": "string",
+                        "maxLength": 100
+                    }
+                },
+                "required": [
+                    "id",
+                    "email",
+                    "createdAt",
+                    "role"
+                ],
+                "additionalProperties": false
+            },
+            "Account": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "type": "string",
+                        "maxLength": 100
+                    },
+                    "emailVerified": {
+                        "type": "boolean"
+                    },
+                    "profilePicture": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [Account](#schema_account) in ISO 8601 format"
+                    }
+                },
+                "required": [
+                    "id",
+                    "email",
+                    "emailVerified",
+                    "createdAt"
+                ],
+                "additionalProperties": false
+            },
+            "Usage": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Id of the usage that it is linked to. It can either be a workspace id or a bot id"
+                    },
+                    "period": {
+                        "type": "string",
+                        "description": "Period of the quota that it is applied to"
+                    },
+                    "value": {
+                        "type": "number",
+                        "description": "Value of the current usage"
+                    },
+                    "quota": {
+                        "type": "number",
+                        "description": "Quota of the current usage"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "invocation_timeout",
+                            "invocation_calls",
+                            "storage_count",
+                            "bot_count",
+                            "knowledgebase_vector_storage",
+                            "workspace_ratelimit",
+                            "table_row_count",
+                            "workspace_member_count",
+                            "integrations_owned_count",
+                            "ai_spend",
+                            "openai_spend",
+                            "bing_search_spend",
+                            "always_alive"
+                        ],
+                        "description": "Usage type that can be used"
+                    }
+                },
+                "required": [
+                    "id",
+                    "period",
+                    "value",
+                    "quota",
+                    "type"
+                ],
+                "additionalProperties": false
+            },
+            "Issue": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "code": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "lastSeenAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "groupedData": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "raw": {
+                                    "type": "string"
+                                },
+                                "pretty": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "raw"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "eventsCount": {
+                        "type": "number"
+                    },
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "user_code",
+                            "limits",
+                            "configuration",
+                            "other"
+                        ]
+                    },
+                    "resolutionLink": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "id",
+                    "code",
+                    "createdAt",
+                    "lastSeenAt",
+                    "title",
+                    "description",
+                    "groupedData",
+                    "eventsCount",
+                    "category",
+                    "resolutionLink"
+                ],
+                "additionalProperties": false
+            },
+            "IssueEvent": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "data": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "raw": {
+                                    "type": "string"
+                                },
+                                "pretty": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "raw"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdAt",
+                    "data"
+                ],
+                "additionalProperties": false
+            },
+            "Activity": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "taskId": {
+                        "type": "string"
+                    },
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "unknown",
+                            "capture",
+                            "bot_message",
+                            "user_message",
+                            "agent_message",
+                            "event",
+                            "action",
+                            "task_status",
+                            "subtask_status",
+                            "exception"
+                        ]
+                    },
+                    "data": {
+                        "type": "object",
+                        "additionalProperties": true
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the activity in ISO 8601 format"
+                    }
+                },
+                "required": [
+                    "id",
+                    "description",
+                    "taskId",
+                    "category",
+                    "data",
+                    "createdAt"
+                ],
+                "additionalProperties": false
+            },
+            "Version": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "additionalProperties": false
+            },
+            "User": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [User](#schema_user)"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [User](#schema_user) in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updating date of the [User](#schema_user) in ISO 8601 format"
+                    },
+                    "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [User](#schema_user). The set of [Tags](/docs/developers/concepts/tags) available on a [User](#schema_user) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Name of the [User](#schema_user)"
+                    },
+                    "pictureUrl": {
+                        "type": "string",
+                        "maxLength": 40000,
+                        "description": "Picture URL of the [User](#schema_user)"
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt",
+                    "tags"
+                ],
+                "description": "The user object represents someone interacting with the bot within a specific integration. The same person interacting with a bot in slack and messenger will be represented with two different users.",
+                "additionalProperties": false
+            },
+            "Conversation": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [Conversation](#schema_conversation)"
+                    },
+                    "currentTaskId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the current [Task](#schema_task)"
+                    },
+                    "currentWorkflowId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the current [Workflow](#schema_workflow)"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [Conversation](#schema_conversation) in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updating date of the [Conversation](#schema_conversation) in ISO 8601 format"
+                    },
+                    "channel": {
+                        "type": "string",
+                        "description": "Name of the channel where the [Conversation](#schema_conversation) is happening"
+                    },
+                    "integration": {
+                        "type": "string",
+                        "description": "Name of the integration that created the [Conversation](#schema_conversation)"
+                    },
+                    "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Conversation](#schema_conversation). The set of [Tags](/docs/developers/concepts/tags) available on a [Conversation](#schema_conversation) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt",
+                    "channel",
+                    "integration",
+                    "tags"
+                ],
+                "description": "The [Conversation](#schema_conversation) object represents an exchange of messages between one or more users. A [Conversation](#schema_conversation) is always linked to an integration's channels. For example, a Slack channel represents a conversation.",
+                "additionalProperties": false
+            },
+            "Event": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [Event](#schema_event)"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [Event](#schema_event) in ISO 8601 format"
+                    },
+                    "type": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Type of the [Event](#schema_event)."
+                    },
+                    "payload": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Payload is the content of the event defined by the integration installed on your bot or one of the default events created by our api."
+                    },
+                    "conversationId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "ID of the [Conversation](#schema_conversation) to link the event to."
+                    },
+                    "userId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "ID of the [User](#schema_user) to link the event to."
+                    },
+                    "messageId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "ID of the [Message](#schema_message) to link the event to."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "pending",
+                            "processed",
+                            "ignored",
+                            "failed",
+                            "scheduled"
+                        ]
+                    },
+                    "failureReason": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "nullable": true,
+                        "description": "Reason why the event failed to be processed"
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdAt",
+                    "type",
+                    "payload",
+                    "status",
+                    "failureReason"
+                ],
+                "description": "The event object represents an action or an occurrence.",
+                "additionalProperties": false
+            },
+            "Message": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [Message](#schema_message)"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [Message](#schema_message) in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Update date of the [Message](#schema_message) in ISO 8601 format"
+                    },
+                    "type": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Type of the [Message](#schema_message) represents the resource type that the message is related to"
+                    },
+                    "payload": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Payload is the content type of the message. Accepted payload options: Text, Image, Choice, Dropdown, Card, Carousel, File, Audio, Video, Location"
+                    },
+                    "direction": {
+                        "type": "string",
+                        "enum": [
+                            "incoming",
+                            "outgoing"
+                        ],
+                        "description": "Direction of the message (`incoming` or `outgoing`)."
+                    },
+                    "userId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "ID of the [User](#schema_user)"
+                    },
+                    "conversationId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "ID of the [Conversation](#schema_conversation)"
+                    },
+                    "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Conversation](#schema_conversation). The set of [Tags](/docs/developers/concepts/tags) available on a [Conversation](#schema_conversation) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt",
+                    "type",
+                    "payload",
+                    "direction",
+                    "userId",
+                    "conversationId",
+                    "tags"
+                ],
+                "description": "The Message object represents a message in a [Conversation](#schema_conversation) for a specific [User](#schema_user).",
+                "additionalProperties": false
+            },
+            "State": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [State](#schema_state)"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [State](#schema_state) in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updating date of the [State](#schema_state) in ISO 8601 format"
+                    },
+                    "botId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [Bot](#schema_bot)"
+                    },
+                    "conversationId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [Conversation](#schema_conversation)"
+                    },
+                    "userId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [User](#schema_user)"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Name of the [State](#schema_state) which is declared inside the bot definition"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "conversation",
+                            "user",
+                            "bot",
+                            "task",
+                            "integration",
+                            "workflow"
+                        ],
+                        "description": "Type of the [State](#schema_state) represents the resource type (`conversation`, `user`, `bot`, `task`, `integration` or `workflow`) that the state is related to"
+                    },
+                    "payload": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Payload is the content of the state defined by your bot."
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt",
+                    "botId",
+                    "name",
+                    "type",
+                    "payload"
+                ],
+                "description": "The state object represents the current payload. A state is always linked to either a bot, a conversation or a user.",
+                "additionalProperties": false
+            },
+            "Task": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [Task](#schema_task)"
+                    },
+                    "title": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Title describing the task"
+                    },
+                    "description": {
+                        "type": "string",
+                        "maxLength": 256,
+                        "description": "All the notes related to the execution of the current task"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Type of the task"
+                    },
+                    "data": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Content related to the task"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "pending",
+                            "in_progress",
+                            "failed",
+                            "completed",
+                            "blocked",
+                            "paused",
+                            "timeout",
+                            "cancelled"
+                        ],
+                        "description": "Status of the task"
+                    },
+                    "parentTaskId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Parent task id is the parent task that created this task"
+                    },
+                    "conversationId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Conversation id related to this task"
+                    },
+                    "userId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Specific user related to this task"
+                    },
+                    "timeoutAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The timeout date where the task should be failed in the ISO 8601 format"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the task in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updating date of the task in ISO 8601 format"
+                    },
+                    "failureReason": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "description": "If the task fails this is the reason behind it"
+                    },
+                    "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Task](#schema_task). Individual keys can be unset by posting an empty value to them."
+                    }
+                },
+                "required": [
+                    "id",
+                    "title",
+                    "description",
+                    "type",
+                    "data",
+                    "status",
+                    "timeoutAt",
+                    "createdAt",
+                    "updatedAt",
+                    "tags"
+                ],
+                "description": "Task definition",
+                "additionalProperties": false
+            },
+            "Workflow": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Id of the [Workflow](#schema_workflow)"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 200,
+                        "description": "Name of the workflow"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "pending",
+                            "in_progress",
+                            "failed",
+                            "completed",
+                            "listening",
+                            "paused",
+                            "timedout",
+                            "cancelled"
+                        ],
+                        "description": "Status of the [Workflow](#schema_workflow)"
+                    },
+                    "input": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Input provided to the [Workflow](#schema_workflow)"
+                    },
+                    "output": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Data returned by the [Workflow](#schema_workflow) output"
+                    },
+                    "parentWorkflowId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Parent [Workflow](#schema_workflow) id is the parent [Workflow](#schema_workflow) that created this [Workflow](#schema_workflow)"
+                    },
+                    "conversationId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "Conversation id related to this [Workflow](#schema_workflow)"
+                    },
+                    "userId": {
+                        "type": "string",
+                        "minLength": 28,
+                        "maxLength": 36,
+                        "description": "User id related to this [Workflow](#schema_workflow)"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date of the [Workflow](#schema_workflow) in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Updating date of the [Workflow](#schema_workflow) in ISO 8601 format"
+                    },
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date when the [Workflow](#schema_workflow) completed in ISO 8601 format"
+                    },
+                    "failureReason": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "description": "If the [Workflow](#schema_workflow) fails this is the reason behind it"
+                    },
+                    "timeoutAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The timeout date when the [Workflow](#schema_workflow) will fail in the ISO 8601 format"
+                    },
+                    "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Workflow](#schema_workflow). Individual keys can be unset by posting an empty value to them."
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "status",
+                    "input",
+                    "output",
+                    "createdAt",
+                    "updatedAt",
+                    "timeoutAt",
+                    "tags"
+                ],
+                "description": "Workflow definition",
+                "additionalProperties": false
+            },
+            "Table": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the table"
+                    },
+                    "name": {
+                        "description": "Required. This name is used to identify your table.",
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "factor": {
+                        "default": 1,
+                        "type": "number",
+                        "minimum": 1,
+                        "maximum": 30,
+                        "description": "The 'factor' multiplies the row's data storage limit by 4KB and its quota count, but can only be set at table creation and not modified later. For instance, a factor of 2 increases storage to 8KB but counts as 2 rows in your quota. The default factor is 1."
+                    },
+                    "frozen": {
+                        "type": "boolean",
+                        "description": "A table designated as \"frozen\" is immutable in terms of its name and schema structure; modifications to its schema or a renaming operation are not permitted. The only action that can be taken on such a table is deletion. The schema established at the time of creation is locked in as the final structure. To implement any changes, the table must be duplicated with the desired alterations."
+                    },
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "$schema": {
+                                "type": "string"
+                            },
+                            "properties": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "object",
+                                                "array",
+                                                "null"
+                                            ]
+                                        },
+                                        "format": {
+                                            "type": "string",
+                                            "enum": [
+                                                "date-time"
+                                            ]
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        },
+                                        "pattern": {
+                                            "type": "string",
+                                            "description": "String properties must match this pattern"
+                                        },
+                                        "enum": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "description": "String properties must be one of these values"
+                                        },
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "string",
+                                                        "number",
+                                                        "boolean",
+                                                        "object",
+                                                        "array",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ],
+                                            "additionalProperties": true,
+                                            "description": "Defines the shape of items in an array"
+                                        },
+                                        "nullable": {
+                                            "default": true,
+                                            "type": "boolean"
+                                        },
+                                        "properties": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "string",
+                                                            "number",
+                                                            "boolean",
+                                                            "object",
+                                                            "array",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "x-zui": {
+                                            "type": "object",
+                                            "properties": {
+                                                "index": {
+                                                    "type": "integer"
+                                                },
+                                                "id": {
+                                                    "type": "string",
+                                                    "description": "[deprecated] ID of the column."
+                                                },
+                                                "searchable": {
+                                                    "type": "boolean",
+                                                    "description": "Indicates if the column is vectorized and searchable."
+                                                },
+                                                "hidden": {
+                                                    "type": "boolean",
+                                                    "description": "Indicates if the field is hidden in the UI"
+                                                },
+                                                "order": {
+                                                    "type": "number",
+                                                    "description": "Order of the column in the UI"
+                                                },
+                                                "width": {
+                                                    "type": "number",
+                                                    "description": "Width of the column in the UI"
+                                                },
+                                                "schemaId": {
+                                                    "type": "string",
+                                                    "description": "ID of the schema"
+                                                },
+                                                "computed": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "action": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "ai",
+                                                                "code",
+                                                                "workflow"
+                                                            ]
+                                                        },
+                                                        "dependencies": {
+                                                            "default": [],
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "prompt": {
+                                                            "type": "string",
+                                                            "description": "Prompt when action is \"ai\""
+                                                        },
+                                                        "code": {
+                                                            "type": "string",
+                                                            "description": "Code to execute when action is \"code\""
+                                                        },
+                                                        "model": {
+                                                            "default": "gpt-4o",
+                                                            "type": "string",
+                                                            "maxLength": 80,
+                                                            "description": "Model to use when action is \"ai\""
+                                                        },
+                                                        "workflowId": {
+                                                            "type": "string",
+                                                            "maxLength": 20,
+                                                            "description": "ID of Workflow to execute when action is \"workflow\""
+                                                        },
+                                                        "enabled": {
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "action"
+                                                    ],
+                                                    "additionalProperties": false
+                                                },
+                                                "typings": {
+                                                    "type": "string",
+                                                    "description": "TypeScript typings for the column. Recommended if the type is \"object\", ex: \"\\{ foo: string; bar: number \\}\""
+                                                }
+                                            },
+                                            "required": [
+                                                "index"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "type",
+                                        "x-zui"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "description": "List of keys/columns in the table."
+                            },
+                            "additionalProperties": {
+                                "type": "boolean",
+                                "enum": [
+                                    true
+                                ],
+                                "description": "Additional properties can be provided, but they will be ignored if no column matches."
+                            },
+                            "required": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "Array of required properties."
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "object"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "properties",
+                            "additionalProperties",
+                            "type"
+                        ],
+                        "additionalProperties": false
+                    },
+                    "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Optional tags to help organize your tables. These should be passed here as an object representing key/value pairs."
+                    },
+                    "isComputeEnabled": {
+                        "type": "boolean",
+                        "description": "Indicates if the table is enabled for computation."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of table creation."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of the last table update."
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "schema"
+                ],
+                "additionalProperties": false
+            },
+            "Column": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the column."
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 30,
+                        "description": "Name of the column, must be within length limits."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Optional descriptive text about the column."
+                    },
+                    "searchable": {
+                        "type": "boolean",
+                        "description": "Indicates if the column is vectorized and searchable."
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "date",
+                            "object"
+                        ],
+                        "description": "Specifies the data type of the column. Use \"object\" for complex data structures."
+                    },
+                    "typings": {
+                        "type": "string",
+                        "description": "TypeScript typings for the column. Recommended if the type is \"object\", ex: \"\\{ foo: string; bar: number \\}\""
+                    },
+                    "computed": {
+                        "type": "object",
+                        "properties": {
+                            "action": {
+                                "type": "string",
+                                "enum": [
+                                    "ai",
+                                    "code",
+                                    "workflow"
+                                ]
+                            },
+                            "dependencies": {
+                                "default": [],
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "prompt": {
+                                "type": "string",
+                                "description": "Prompt when action is \"ai\""
+                            },
+                            "code": {
+                                "type": "string",
+                                "description": "Code to execute when action is \"code\""
+                            },
+                            "model": {
+                                "default": "gpt-4o",
+                                "type": "string",
+                                "maxLength": 80,
+                                "description": "Model to use when action is \"ai\""
+                            },
+                            "workflowId": {
+                                "type": "string",
+                                "maxLength": 20,
+                                "description": "ID of Workflow to execute when action is \"workflow\""
+                            },
+                            "enabled": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "action"
+                        ],
+                        "additionalProperties": false
+                    },
+                    "schema": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
+                },
+                "required": [
+                    "name",
+                    "type"
+                ],
+                "additionalProperties": false
+            },
+            "Row": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "number",
+                        "description": "Unique identifier for the row."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of row creation."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of the last row update."
+                    },
+                    "computed": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                                "status": {
+                                    "type": "string"
+                                },
+                                "error": {
+                                    "type": "string"
+                                },
+                                "updatedBy": {
+                                    "type": "string"
+                                },
+                                "updatedAt": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "status"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "stale": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "[Read-only] List of stale values that are waiting to be recomputed."
+                    },
+                    "similarity": {
+                        "type": "number",
+                        "description": "Optional numeric value indicating similarity, when using findTableRows."
+                    }
+                },
+                "required": [
+                    "id",
+                    "computed"
+                ],
+                "additionalProperties": true
+            },
+            "File": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "File ID"
+                    },
+                    "botId": {
+                        "type": "string",
+                        "description": "The ID of the bot the file belongs to"
+                    },
+                    "key": {
+                        "type": "string",
+                        "description": "Unique key for the file. Must be unique across the bot (and the integration, when applicable)."
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "URL to retrieve the file content. This URL will be ready to use once the file is uploaded.\n\nIf the file has a `public_content` policy, this will contain the permanent public URL to retrieve the file, otherwise this will contain a temporary pre-signed URL to download the file which should be used shortly after retrieving and should not be stored long-term as the URL will expire after a short timeframe."
+                    },
+                    "size": {
+                        "type": "number",
+                        "description": "File size in bytes. Non-null if file upload status is \"COMPLETE\".",
+                        "nullable": true
+                    },
+                    "contentType": {
+                        "type": "string",
+                        "description": "MIME type of the file's content"
+                    },
+                    "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "maxLength": 1000
+                        },
+                        "description": "The tags of the file as an object of key/value pairs"
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "nullable": true
+                        },
+                        "description": "Metadata of the file as an object of key/value pairs. The values can be of any type."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "description": "File creation timestamp in ISO 8601 format"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "description": "File last update timestamp in ISO 8601 format"
+                    },
+                    "accessPolicies": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "integrations",
+                                "public_content"
+                            ]
+                        },
+                        "description": "Access policies configured for the file."
+                    },
+                    "index": {
+                        "type": "boolean",
+                        "description": "Whether the file was requested to be indexed for search or not."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "upload_pending",
+                            "upload_failed",
+                            "upload_completed",
+                            "indexing_pending",
+                            "indexing_failed",
+                            "indexing_completed"
+                        ],
+                        "description": "Status of the file. If the status is `upload_pending`, the file content has not been uploaded yet. The status will be set to `upload_completed` once the file content has been uploaded successfully.\n\nIf the upload failed for any reason (e.g. exceeding the storage quota or the maximum file size limit) the status will be set to `upload_failed` and the reason for the failure will be available in the `failedStatusReason` field of the file.\n\nHowever, if the file has been uploaded and the `index` attribute was set to `true` on the file, the status will immediately transition to the `indexing_pending` status (the `upload_completed` status step will be skipped).\n\nOnce the indexing is completed and the file is ready to be used for searching its status will be set to `indexing_completed`. If the indexing failed the status will be set to `indexing_failed` and the reason for the failure will be available in the `failedStatusReason` field."
+                    },
+                    "failedStatusReason": {
+                        "type": "string",
+                        "description": "If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."
+                    },
+                    "expiresAt": {
+                        "type": "string",
+                        "description": "File expiry timestamp in ISO 8601 format"
+                    }
+                },
+                "required": [
+                    "id",
+                    "botId",
+                    "key",
+                    "url",
+                    "size",
+                    "contentType",
+                    "tags",
+                    "metadata",
+                    "createdAt",
+                    "updatedAt",
+                    "accessPolicies",
+                    "index",
+                    "status"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "responses": {
+            "createConversationResponse": {
+                "description": "Returns a [Conversation](#schema_conversation) object if creation succeeds. Returns [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "conversation": {
+                                    "$ref": "#/components/schemas/Conversation"
+                                }
+                            },
+                            "required": [
+                                "conversation"
+                            ],
+                            "title": "createConversationResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getConversationResponse": {
+                "description": "Returns a [Conversation](#schema_conversation) object if a valid identifier was provided. Returns [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "conversation": {
+                                    "$ref": "#/components/schemas/Conversation"
+                                }
+                            },
+                            "required": [
+                                "conversation"
+                            ],
+                            "title": "getConversationResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listConversationsResponse": {
+                "description": "Returns a list of [Conversation](#schema_conversation) objects",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "conversations": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Conversation"
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "conversations",
+                                "meta"
+                            ],
+                            "title": "listConversationsResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getOrCreateConversationResponse": {
+                "description": "Returns a [Conversation](#schema_conversation) object if a valid identifier was provided. Returns [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "conversation": {
+                                    "$ref": "#/components/schemas/Conversation"
+                                }
+                            },
+                            "required": [
+                                "conversation"
+                            ],
+                            "title": "getOrCreateConversationResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateConversationResponse": {
+                "description": "Returns an updated [Conversation](#schema_conversation) object if a valid identifier was provided. Returns [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "conversation": {
+                                    "$ref": "#/components/schemas/Conversation"
+                                }
+                            },
+                            "required": [
+                                "conversation"
+                            ],
+                            "title": "updateConversationResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "deleteConversationResponse": {
+                "description": "Returns the [Conversation](#schema_conversation) object that was deleted",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "deleteConversationResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listParticipantsResponse": {
+                "description": "Returns a list of [Participant](#schema_participant) objects",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "participants": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/User"
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "participants",
+                                "meta"
+                            ],
+                            "title": "listParticipantsResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "addParticipantResponse": {
+                "description": "Returns the [Participant](#schema_participant) object",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "participant": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            },
+                            "required": [
+                                "participant"
+                            ],
+                            "title": "addParticipantResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getParticipantResponse": {
+                "description": "Returns the [Participant](#schema_participant) object",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "participant": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            },
+                            "required": [
+                                "participant"
+                            ],
+                            "title": "getParticipantResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "removeParticipantResponse": {
+                "description": "Returns an empty object",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "removeParticipantResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createEventResponse": {
+                "description": "Returns a [Event](#schema_event) object if creation succeeds. Returns [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "event": {
+                                    "$ref": "#/components/schemas/Event"
+                                }
+                            },
+                            "required": [
+                                "event"
+                            ],
+                            "title": "createEventResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getEventResponse": {
+                "description": "Returns the [Event](#schema_event) object if a valid identifiers were provided. Returns [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "event": {
+                                    "$ref": "#/components/schemas/Event"
+                                }
+                            },
+                            "required": [
+                                "event"
+                            ],
+                            "title": "getEventResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listEventsResponse": {
+                "description": "Returns a list of [Event](#schema_event) objects",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "events": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Event"
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "events",
+                                "meta"
+                            ],
+                            "title": "listEventsResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createMessageResponse": {
+                "description": "Returns a [Message](#schema_message) object if creation succeeds.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            },
+                            "required": [
+                                "message"
+                            ],
+                            "title": "createMessageResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getOrCreateMessageResponse": {
+                "description": "Returns a [Message](#schema_message) object if a valid identifier was provided. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            },
+                            "required": [
+                                "message"
+                            ],
+                            "title": "getOrCreateMessageResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getMessageResponse": {
+                "description": "Returns a [Message](#schema_message) object if a valid identifier was provided. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            },
+                            "required": [
+                                "message"
+                            ],
+                            "title": "getMessageResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateMessageResponse": {
+                "description": "Message information",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            },
+                            "required": [
+                                "message"
+                            ],
+                            "title": "updateMessageResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listMessagesResponse": {
+                "description": "Returns a list of [Message](#schema_message) objects.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "messages": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Message"
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "messages",
+                                "meta"
+                            ],
+                            "title": "listMessagesResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "deleteMessageResponse": {
+                "description": "Returns the [Message](#schema_message) object that was deleted",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "deleteMessageResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createUserResponse": {
+                "description": "Returns a [User](#schema_user) object if creation succeeds. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "user": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            },
+                            "required": [
+                                "user"
+                            ],
+                            "title": "createUserResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getUserResponse": {
+                "description": "Returns a [User](#schema_user) object if a valid identifier was provided. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "user": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            },
+                            "required": [
+                                "user"
+                            ],
+                            "title": "getUserResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listUsersResponse": {
+                "description": "Returns a list of [User](#schema_user) objects",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "users": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/User"
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "users",
+                                "meta"
+                            ],
+                            "title": "listUsersResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getOrCreateUserResponse": {
+                "description": "Returns a [User](#schema_user) object if a valid identifier was provided. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "user": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            },
+                            "required": [
+                                "user"
+                            ],
+                            "title": "getOrCreateUserResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateUserResponse": {
+                "description": "Returns an updated [User](#schema_user) object if a valid identifier was provided. Returns [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "user": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            },
+                            "required": [
+                                "user"
+                            ],
+                            "title": "updateUserResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "deleteUserResponse": {
+                "description": "Returns the [User](#schema_user) object that was deleted",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "deleteUserResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "setStateExpiryResponse": {
+                "description": "Returns the updated [State](#schema_state) object if a valid identifier was provided. Returns an [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "state": {
+                                    "$ref": "#/components/schemas/State"
+                                }
+                            },
+                            "required": [
+                                "state"
+                            ],
+                            "title": "setStateExpiryResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getStateResponse": {
+                "description": "Returns the [State](#schema_state) object if a valid identifiers were provided. Returns [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "state": {
+                                    "$ref": "#/components/schemas/State"
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cached": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "cached"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "state",
+                                "meta"
+                            ],
+                            "title": "getStateResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "setStateResponse": {
+                "description": "Returns the updated [State](#schema_state) object if a valid identifier was provided. Returns an [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "state": {
+                                    "$ref": "#/components/schemas/State"
+                                }
+                            },
+                            "required": [
+                                "state"
+                            ],
+                            "title": "setStateResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getOrSetStateResponse": {
+                "description": "Returns the [State](#schema_state) object if a valid identifiers were provided. Returns [an error](#errors) otherwise.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "state": {
+                                    "$ref": "#/components/schemas/State"
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cached": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "cached"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "state",
+                                "meta"
+                            ],
+                            "title": "getOrSetStateResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "patchStateResponse": {
+                "description": "Returns the updated [State](#schema_state) object if a valid identifier was provided. Returns an [an error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "state": {
+                                    "$ref": "#/components/schemas/State"
+                                }
+                            },
+                            "required": [
+                                "state"
+                            ],
+                            "title": "patchStateResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "callActionResponse": {
+                "description": "Action payload",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "output": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Input of the action"
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cached": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "cached"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "output",
+                                "meta"
+                            ],
+                            "title": "callActionResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "configureIntegrationResponse": {
+                "description": "Configuration of the integration",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "configureIntegrationResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getTaskResponse": {
+                "description": "Returns a [Task](#schema_task) object if a valid identifier was provided. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "task": {
+                                    "$ref": "#/components/schemas/Task"
+                                }
+                            },
+                            "required": [
+                                "task"
+                            ],
+                            "title": "getTaskResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createTaskResponse": {
+                "description": "Returns a [Task](#schema_task) object if creation succeeds. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "task": {
+                                    "$ref": "#/components/schemas/Task"
+                                }
+                            },
+                            "required": [
+                                "task"
+                            ],
+                            "title": "createTaskResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateTaskResponse": {
+                "description": "Returns an updated [Task](#schema_task) object if a valid identifier was provided. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "task": {
+                                    "$ref": "#/components/schemas/Task"
+                                }
+                            },
+                            "required": [
+                                "task"
+                            ],
+                            "title": "updateTaskResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "deleteTaskResponse": {
+                "description": "Returns the [Task](#schema_task) object that was deleted",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "deleteTaskResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listTasksResponse": {
+                "description": "Returns a list of [Task](#schema_task) objects",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "tasks": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Task"
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "tasks",
+                                "meta"
+                            ],
+                            "title": "listTasksResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createWorkflowResponse": {
+                "description": "Returns a [Workflow](#schema_workflow) object if creation succeeds. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "workflow": {
+                                    "$ref": "#/components/schemas/Workflow"
+                                }
+                            },
+                            "required": [
+                                "workflow"
+                            ],
+                            "title": "createWorkflowResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getWorkflowResponse": {
+                "description": "Returns a [Workflow](#schema_workflow) object if a valid identifier was provided. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "workflow": {
+                                    "$ref": "#/components/schemas/Workflow"
+                                }
+                            },
+                            "required": [
+                                "workflow"
+                            ],
+                            "title": "getWorkflowResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateWorkflowResponse": {
+                "description": "Returns an updated [Workflow](#schema_workflow) object if a valid identifier was provided. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "workflow": {
+                                    "$ref": "#/components/schemas/Workflow"
+                                }
+                            },
+                            "required": [
+                                "workflow"
+                            ],
+                            "title": "updateWorkflowResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "deleteWorkflowResponse": {
+                "description": "Returns the [Workflow](#schema_workflow) object that was deleted",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "deleteWorkflowResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listWorkflowsResponse": {
+                "description": "Returns a list of [Workflow](#schema_workflow) objects",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "workflows": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Workflow"
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "workflows",
+                                "meta"
+                            ],
+                            "title": "listWorkflowsResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getOrCreateWorkflowResponse": {
+                "description": "Returns a [Workflow](#schema_workflow) object if creation succeeds. Returns an [Error](#errors) otherwise",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "workflow": {
+                                    "$ref": "#/components/schemas/Workflow"
+                                }
+                            },
+                            "required": [
+                                "workflow"
+                            ],
+                            "title": "getOrCreateWorkflowResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "listTagValuesResponse": {
+                "description": "Empty response",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "tags": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "value"
+                                        ]
+                                    }
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nextToken": {
+                                            "type": "string",
+                                            "description": "The token to use to retrieve the next page of results, passed as a query string parameter (value should be URL-encoded) to this API endpoint."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "tags",
+                                "meta"
+                            ],
+                            "title": "listTagValuesResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "trackAnalyticsResponse": {
+                "description": "Success",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "trackAnalyticsResponse",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+        },
+        "requestBodies": {
+            "createConversationBody": {
+                "description": "Conversation data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "channel": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Channel name"
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Tags for the [Conversation](#schema_conversation)"
+                                },
+                                "integrationName": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "[DEPRECATED] To create a conversation from within a bot, call an action of the integration instead.",
+                                    "deprecated": true
+                                }
+                            },
+                            "required": [
+                                "channel",
+                                "tags"
+                            ],
+                            "title": "createConversationBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getOrCreateConversationBody": {
+                "description": "Conversation data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "channel": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Channel name"
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Tags for the [Conversation](#schema_conversation)"
+                                },
+                                "integrationName": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "[DEPRECATED] To create a conversation from within a bot, call an action of the integration instead.",
+                                    "deprecated": true
+                                },
+                                "discriminateByTags": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Optional list of tag names to use for strict matching when looking up existing conversations. If provided, all specified tags must match exactly for a conversation to be considered a match. For example, with an existing conversation whose tags are {\"foo\": \"a\", \"bar\": \"b\", baz: \"c\"}: Without this parameter, ALL tags must match exactly. With [\"bar\",\"baz\"], all listed tags must match their values, and other tags are not considered."
+                                }
+                            },
+                            "required": [
+                                "channel",
+                                "tags"
+                            ],
+                            "title": "getOrCreateConversationBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateConversationBody": {
+                "description": "Conversation data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "currentTaskId": {
+                                    "type": "string"
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Tags for the [Conversation](#schema_conversation)"
+                                }
+                            },
+                            "title": "updateConversationBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "addParticipantBody": {
+                "description": "Participant data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "userId": {
+                                    "type": "string",
+                                    "minLength": 28,
+                                    "maxLength": 36,
+                                    "description": "User id"
+                                }
+                            },
+                            "required": [
+                                "userId"
+                            ],
+                            "title": "addParticipantBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createEventBody": {
+                "description": "Event data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Type of the [Event](#schema_event)."
+                                },
+                                "payload": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Payload is the content of the event defined by the integration installed on your bot or one of the default events created by our API."
+                                },
+                                "schedule": {
+                                    "type": "object",
+                                    "properties": {
+                                        "dateTime": {
+                                            "type": "string",
+                                            "maxLength": 28,
+                                            "minLength": 24,
+                                            "description": "When the [Event](#schema_event) will be sent, in the ISO 8601 format"
+                                        },
+                                        "delay": {
+                                            "type": "number",
+                                            "description": "Delay in milliseconds before sending the [Event](#schema_event)"
+                                        }
+                                    },
+                                    "description": "Schedule the Event to be sent at a specific time. Either dateTime or delay must be provided.",
+                                    "additionalProperties": false
+                                },
+                                "conversationId": {
+                                    "type": "string",
+                                    "minLength": 28,
+                                    "maxLength": 36,
+                                    "description": "ID of the [Conversation](#schema_conversation) to link the event to."
+                                },
+                                "userId": {
+                                    "type": "string",
+                                    "minLength": 28,
+                                    "maxLength": 36,
+                                    "description": "ID of the [User](#schema_user) to link the event to."
+                                },
+                                "messageId": {
+                                    "type": "string",
+                                    "minLength": 28,
+                                    "maxLength": 36,
+                                    "description": "ID of the [Message](#schema_message) to link the event to."
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "payload"
+                            ],
+                            "title": "createEventBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createMessageBody": {
+                "description": "Message data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "payload": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Payload is the content type of the message. Accepted payload options: Text, Image, Choice, Dropdown, Card, Carousel, File, Audio, Video, Location"
+                                },
+                                "userId": {
+                                    "type": "string",
+                                    "minLength": 28,
+                                    "maxLength": 36,
+                                    "description": "ID of the [User](#schema_user)"
+                                },
+                                "conversationId": {
+                                    "type": "string",
+                                    "minLength": 28,
+                                    "maxLength": 36,
+                                    "description": "ID of the [Conversation](#schema_conversation)"
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Type of the [Message](#schema_message) represents the resource type that the message is related to"
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Message](#schema_message). The set of [Tags](/docs/developers/concepts/tags) available on a [Message](#schema_message) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."
+                                },
+                                "schedule": {
+                                    "type": "object",
+                                    "properties": {
+                                        "dateTime": {
+                                            "type": "string",
+                                            "maxLength": 28,
+                                            "minLength": 24,
+                                            "description": "When the [Message](#schema_message) will be sent, in the ISO 8601 format"
+                                        },
+                                        "delay": {
+                                            "type": "number",
+                                            "description": "Delay in milliseconds before sending the [Message](#schema_message)"
+                                        }
+                                    },
+                                    "description": "Schedule the Message to be sent at a specific time. Either dateTime or delay must be provided.",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "payload",
+                                "userId",
+                                "conversationId",
+                                "type",
+                                "tags"
+                            ],
+                            "title": "createMessageBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getOrCreateMessageBody": {
+                "description": "Message data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "payload": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Payload is the content type of the message. Accepted payload options: Text, Image, Choice, Dropdown, Card, Carousel, File, Audio, Video, Location"
+                                },
+                                "userId": {
+                                    "type": "string",
+                                    "minLength": 28,
+                                    "maxLength": 36,
+                                    "description": "ID of the [User](#schema_user)"
+                                },
+                                "conversationId": {
+                                    "type": "string",
+                                    "minLength": 28,
+                                    "maxLength": 36,
+                                    "description": "ID of the [Conversation](#schema_conversation)"
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Type of the [Message](#schema_message) represents the resource type that the message is related to"
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Message](#schema_message). The set of [Tags](/docs/developers/concepts/tags) available on a [Message](#schema_message) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."
+                                },
+                                "schedule": {
+                                    "type": "object",
+                                    "properties": {
+                                        "dateTime": {
+                                            "type": "string",
+                                            "maxLength": 28,
+                                            "minLength": 24,
+                                            "description": "When the [Message](#schema_message) will be sent, in the ISO 8601 format"
+                                        },
+                                        "delay": {
+                                            "type": "number",
+                                            "description": "Delay in milliseconds before sending the [Message](#schema_message)"
+                                        }
+                                    },
+                                    "description": "Schedule the Message to be sent at a specific time. Either dateTime or delay must be provided.",
+                                    "additionalProperties": false
+                                },
+                                "discriminateByTags": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Optional list of tag names to use for strict matching when looking up existing messages. If provided, all specified tags must match exactly for a message to be considered a match. For example, with an existing message whose tags are {\"foo\": \"a\", \"bar\": \"b\", baz: \"c\"}: Without this parameter, ALL tags must match exactly. With [\"bar\",\"baz\"], all listed tags must match their values, and other tags are not considered."
+                                }
+                            },
+                            "required": [
+                                "payload",
+                                "userId",
+                                "conversationId",
+                                "type",
+                                "tags"
+                            ],
+                            "title": "getOrCreateMessageBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateMessageBody": {
+                "description": "Message data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Conversation](#schema_conversation). The set of [Tags](/docs/developers/concepts/tags) available on a [Conversation](#schema_conversation) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."
+                                },
+                                "payload": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Payload is the content type of the message. Accepted payload options: Text, Image, Choice, Dropdown, Card, Carousel, File, Audio, Video, Location"
+                                }
+                            },
+                            "required": [
+                                "tags"
+                            ],
+                            "title": "updateMessageBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createUserBody": {
+                "description": "User data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Tags for the [User](#schema_user)"
+                                },
+                                "integrationName": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "[DEPRECATED] To create a [User](#schema_user) from within a bot, call an action of the integration instead.",
+                                    "deprecated": true
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Name of the user"
+                                },
+                                "pictureUrl": {
+                                    "type": "string",
+                                    "maxLength": 40000,
+                                    "description": "URI of the user picture"
+                                }
+                            },
+                            "required": [
+                                "tags"
+                            ],
+                            "title": "createUserBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getOrCreateUserBody": {
+                "description": "User data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Tags for the [User](#schema_user)"
+                                },
+                                "integrationName": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "[DEPRECATED] To create a [User](#schema_user) from within a bot, call an action of the integration instead.",
+                                    "deprecated": true
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Name of the user"
+                                },
+                                "pictureUrl": {
+                                    "type": "string",
+                                    "maxLength": 40000,
+                                    "description": "URI of the user picture"
+                                },
+                                "discriminateByTags": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Optional list of tag names to use for strict matching when looking up existing users. If provided, all specified tags must match exactly for a user to be considered a match. For example, with an existing user whose tags are {\"foo\": \"a\", \"bar\": \"b\", baz: \"c\"}: Without this parameter, ALL tags must match exactly. With [\"bar\",\"baz\"], all listed tags must match their values, and other tags are not considered."
+                                }
+                            },
+                            "required": [
+                                "tags"
+                            ],
+                            "title": "getOrCreateUserBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateUserBody": {
+                "description": "User data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Tags for the [User](#schema_user)"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Name of the user"
+                                },
+                                "pictureUrl": {
+                                    "type": "string",
+                                    "maxLength": 40000,
+                                    "nullable": true,
+                                    "description": "URI of the user picture"
+                                }
+                            },
+                            "title": "updateUserBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "setStateExpiryBody": {
+                "description": "State expiry",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "expiry": {
+                                    "type": "number",
+                                    "minimum": 1,
+                                    "maximum": 2592000000,
+                                    "nullable": true,
+                                    "description": "Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."
+                                }
+                            },
+                            "required": [
+                                "expiry"
+                            ],
+                            "title": "setStateExpiryBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "setStateBody": {
+                "description": "State content",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "payload": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "nullable": true,
+                                    "description": "Payload is the content of the state defined by your bot."
+                                },
+                                "expiry": {
+                                    "type": "number",
+                                    "minimum": 1,
+                                    "maximum": 2592000000,
+                                    "nullable": true,
+                                    "description": "Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."
+                                }
+                            },
+                            "required": [
+                                "payload"
+                            ],
+                            "title": "setStateBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getOrSetStateBody": {
+                "description": "State content",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "payload": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Payload is the content of the state defined by your bot."
+                                },
+                                "expiry": {
+                                    "type": "number",
+                                    "minimum": 1,
+                                    "maximum": 2592000000,
+                                    "nullable": true,
+                                    "description": "Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."
+                                }
+                            },
+                            "required": [
+                                "payload"
+                            ],
+                            "title": "getOrSetStateBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "patchStateBody": {
+                "description": "State content",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "payload": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Payload is the content of the state defined by your bot."
+                                }
+                            },
+                            "required": [
+                                "payload"
+                            ],
+                            "title": "patchStateBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "callActionBody": {
+                "description": "Action payload",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Type of the action"
+                                },
+                                "input": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Input of the action"
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "input"
+                            ],
+                            "title": "callActionBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "configureIntegrationBody": {
+                "description": "Configuration of the integration",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "identifier": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Unique identifier of the integration that was installed on the bot"
+                                },
+                                "scheduleRegisterCall": {
+                                    "type": "string",
+                                    "enum": [
+                                        "hourly",
+                                        "daily",
+                                        "weekly",
+                                        "bi-weekly",
+                                        "monthly",
+                                        "bi-monthly",
+                                        "quarterly",
+                                        "yearly"
+                                    ],
+                                    "description": "Recurring schedule on which `register()` will be called on the integration"
+                                },
+                                "sandboxIdentifiers": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "nullable": true,
+                                        "additionalProperties": false
+                                    },
+                                    "nullable": true,
+                                    "description": "Sandbox identifiers for the integration. Setting this to null will remove all sandbox identifiers. Setting an individual sandbox identifier to null will remove that sandbox identifier. This is an experimental feature meant to be used by specific integrations."
+                                }
+                            },
+                            "title": "configureIntegrationBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createTaskBody": {
+                "description": "Task data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "maxLength": 2000,
+                                    "description": "Title describing the task"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "maxLength": 20000,
+                                    "description": "All the notes related to the execution of the current task"
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "maxLength": 200,
+                                    "description": "Type of the task"
+                                },
+                                "data": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Content related to the task"
+                                },
+                                "parentTaskId": {
+                                    "type": "string",
+                                    "description": "Parent task id is the parent task that created this task"
+                                },
+                                "conversationId": {
+                                    "type": "string",
+                                    "description": "Conversation id related to this task"
+                                },
+                                "userId": {
+                                    "type": "string",
+                                    "description": "Specific user related to this task"
+                                },
+                                "timeoutAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The timeout date where the task should be failed in the ISO 8601 format"
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Tags for the [Task](#schema_task)"
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "conversationId"
+                            ],
+                            "title": "createTaskBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateTaskBody": {
+                "description": "Task data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string",
+                                    "description": "Title describing the task"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "All the notes related to the execution of the current task"
+                                },
+                                "data": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Content related to the task"
+                                },
+                                "timeoutAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The timeout date where the task should be failed in the ISO 8601 format"
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "enum": [
+                                        "pending",
+                                        "in_progress",
+                                        "failed",
+                                        "completed",
+                                        "blocked",
+                                        "paused",
+                                        "timeout",
+                                        "cancelled"
+                                    ],
+                                    "description": "Status of the task"
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Tags for the [Task](#schema_task)"
+                                }
+                            },
+                            "title": "updateTaskBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "createWorkflowBody": {
+                "description": "Workflow data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the workflow"
+                                },
+                                "input": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Content related to the workflow"
+                                },
+                                "parentWorkflowId": {
+                                    "type": "string",
+                                    "description": "Parent workflow id is the parent workflow that created this workflow"
+                                },
+                                "conversationId": {
+                                    "type": "string",
+                                    "description": "Conversation id related to this workflow"
+                                },
+                                "userId": {
+                                    "type": "string",
+                                    "description": "Specific user related to this workflow"
+                                },
+                                "timeoutAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The timeout date where the workflow should be failed in the ISO 8601 format"
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Tags for the [Workflow](#schema_workflow)"
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "enum": [
+                                        "pending",
+                                        "in_progress"
+                                    ]
+                                },
+                                "eventId": {
+                                    "type": "string",
+                                    "description": "Event id must be specified if the workflow is created with the status in_progress"
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "status"
+                            ],
+                            "title": "createWorkflowBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "updateWorkflowBody": {
+                "description": "Workflow data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "output": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Content related to the workflow"
+                                },
+                                "timeoutAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The timeout date where the workflow should be failed in the ISO 8601 format"
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "enum": [
+                                        "completed",
+                                        "cancelled",
+                                        "listening",
+                                        "paused",
+                                        "failed",
+                                        "in_progress"
+                                    ],
+                                    "description": "Status of the workflow"
+                                },
+                                "failureReason": {
+                                    "type": "string",
+                                    "description": "Reason why the workflow failed"
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Tags for the [Workflow](#schema_workflow)"
+                                },
+                                "userId": {
+                                    "type": "string",
+                                    "description": "Specific user related to this workflow"
+                                },
+                                "eventId": {
+                                    "type": "string",
+                                    "description": "Event id must be specified if the workflow is updated with the status in_progress"
+                                }
+                            },
+                            "title": "updateWorkflowBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "getOrCreateWorkflowBody": {
+                "description": "Workflow data",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the workflow"
+                                },
+                                "input": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Content related to the workflow"
+                                },
+                                "parentWorkflowId": {
+                                    "type": "string",
+                                    "description": "Parent workflow id is the parent workflow that created this workflow"
+                                },
+                                "conversationId": {
+                                    "type": "string",
+                                    "description": "Conversation id related to this workflow"
+                                },
+                                "userId": {
+                                    "type": "string",
+                                    "description": "Specific user related to this workflow"
+                                },
+                                "timeoutAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "The timeout date where the workflow should be failed in the ISO 8601 format"
+                                },
+                                "tags": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string",
+                                        "maxLength": 500
+                                    },
+                                    "description": "Tags for the [Workflow](#schema_workflow)"
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "enum": [
+                                        "pending",
+                                        "in_progress"
+                                    ]
+                                },
+                                "eventId": {
+                                    "type": "string",
+                                    "description": "Event id must be specified if the workflow is created with the status in_progress"
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "status"
+                            ],
+                            "title": "getOrCreateWorkflowBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "trackAnalyticsBody": {
+                "description": "Add an event to the analytics",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 200
+                                },
+                                "count": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "count"
+                            ],
+                            "title": "trackAnalyticsBody",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+        },
+        "parameters": {}
+    },
+    "security": [
+        {
+            "BearerAuth": [],
+            "BotIdHeader": []
+        }
+    ]
+}

--- a/tables-openapi.json
+++ b/tables-openapi.json
@@ -1,7 +1,15 @@
 {
   "openapi": "3.0.0",
-  "servers": [{ "url": "https://api.botpress.cloud" }],
-  "info": { "title": "Botpress API", "description": "API for Botpress Cloud", "version": "1.1.0" },
+  "servers": [
+    {
+      "url": "https://api.botpress.cloud"
+    }
+  ],
+  "info": {
+    "title": "Botpress API",
+    "description": "API for Botpress Cloud",
+    "version": "1.1.0"
+  },
   "paths": {
     "/v1/tables": {
       "get": {
@@ -12,12 +20,21 @@
             "name": "tags",
             "in": "query",
             "description": "Optional filters to narrow down the list by tags associated with tables.",
-            "schema": { "type": "object", "additionalProperties": { "type": "string" } }
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/listTablesResponse" },
-          "default": { "$ref": "#/components/responses/listTablesResponse" }
+          "200": {
+            "$ref": "#/components/responses/listTablesResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/listTablesResponse"
+          }
         }
       },
       "post": {
@@ -25,10 +42,16 @@
         "description": "Initiates the creation of a new table based on the provided schema, excluding system-managed fields like IDs and timestamps.",
         "parameters": [],
         "responses": {
-          "200": { "$ref": "#/components/responses/createTableResponse" },
-          "default": { "$ref": "#/components/responses/createTableResponse" }
+          "200": {
+            "$ref": "#/components/responses/createTableResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/createTableResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/createTableBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/createTableBody"
+        }
       }
     },
     "/v1/tables/{table}": {
@@ -41,12 +64,18 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/getTableResponse" },
-          "default": { "$ref": "#/components/responses/getTableResponse" }
+          "200": {
+            "$ref": "#/components/responses/getTableResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/getTableResponse"
+          }
         }
       },
       "post": {
@@ -58,14 +87,22 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/getOrCreateTableResponse" },
-          "default": { "$ref": "#/components/responses/getOrCreateTableResponse" }
+          "200": {
+            "$ref": "#/components/responses/getOrCreateTableResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/getOrCreateTableResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/getOrCreateTableBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/getOrCreateTableBody"
+        }
       },
       "put": {
         "operationId": "updateTable",
@@ -76,14 +113,22 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/updateTableResponse" },
-          "default": { "$ref": "#/components/responses/updateTableResponse" }
+          "200": {
+            "$ref": "#/components/responses/updateTableResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/updateTableResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/updateTableBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/updateTableBody"
+        }
       },
       "delete": {
         "operationId": "deleteTable",
@@ -94,12 +139,18 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/deleteTableResponse" },
-          "default": { "$ref": "#/components/responses/deleteTableResponse" }
+          "200": {
+            "$ref": "#/components/responses/deleteTableResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/deleteTableResponse"
+          }
         }
       }
     },
@@ -113,14 +164,22 @@
             "in": "path",
             "description": "The table's unique identifier",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/duplicateTableResponse" },
-          "default": { "$ref": "#/components/responses/duplicateTableResponse" }
+          "200": {
+            "$ref": "#/components/responses/duplicateTableResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/duplicateTableResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/duplicateTableBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/duplicateTableBody"
+        }
       }
     },
     "/v1/tables/{table}/export": {
@@ -133,24 +192,39 @@
             "in": "path",
             "description": "The table's unique identifier",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "format",
             "in": "query",
             "description": "The format of the exported file. CSV includes only the data while JSON includes the schema.",
-            "schema": { "type": "string", "enum": ["csv", "json"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "csv",
+                "json"
+              ]
+            }
           },
           {
             "name": "compress",
             "in": "query",
             "description": "Whether or not the export is compressed (gzipped).",
-            "schema": { "default": true, "type": "boolean" }
+            "schema": {
+              "default": true,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/exportTableResponse" },
-          "default": { "$ref": "#/components/responses/exportTableResponse" }
+          "200": {
+            "$ref": "#/components/responses/exportTableResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/exportTableResponse"
+          }
         }
       }
     },
@@ -164,12 +238,18 @@
             "in": "path",
             "description": "The table's unique identifier",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/getTableJobsResponse" },
-          "default": { "$ref": "#/components/responses/getTableJobsResponse" }
+          "200": {
+            "$ref": "#/components/responses/getTableJobsResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/getTableJobsResponse"
+          }
         }
       }
     },
@@ -183,14 +263,22 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/importTableResponse" },
-          "default": { "$ref": "#/components/responses/importTableResponse" }
+          "200": {
+            "$ref": "#/components/responses/importTableResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/importTableResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/importTableBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/importTableBody"
+        }
       }
     },
     "/v1/tables/{table}/column": {
@@ -203,14 +291,22 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/renameTableColumnResponse" },
-          "default": { "$ref": "#/components/responses/renameTableColumnResponse" }
+          "200": {
+            "$ref": "#/components/responses/renameTableColumnResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/renameTableColumnResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/renameTableColumnBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/renameTableColumnBody"
+        }
       }
     },
     "/v1/tables/{table}/row": {
@@ -223,19 +319,27 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "id",
             "in": "query",
             "description": "Identifier of the row within the table.",
             "required": true,
-            "schema": { "type": "integer" }
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/getTableRowResponse" },
-          "default": { "$ref": "#/components/responses/getTableRowResponse" }
+          "200": {
+            "$ref": "#/components/responses/getTableRowResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/getTableRowResponse"
+          }
         }
       }
     },
@@ -249,14 +353,22 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/findTableRowsResponse" },
-          "default": { "$ref": "#/components/responses/findTableRowsResponse" }
+          "200": {
+            "$ref": "#/components/responses/findTableRowsResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/findTableRowsResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/findTableRowsBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/findTableRowsBody"
+        }
       }
     },
     "/v1/tables/{table}/rows": {
@@ -269,14 +381,22 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/createTableRowsResponse" },
-          "default": { "$ref": "#/components/responses/createTableRowsResponse" }
+          "200": {
+            "$ref": "#/components/responses/createTableRowsResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/createTableRowsResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/createTableRowsBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/createTableRowsBody"
+        }
       },
       "put": {
         "operationId": "updateTableRows",
@@ -287,14 +407,22 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/updateTableRowsResponse" },
-          "default": { "$ref": "#/components/responses/updateTableRowsResponse" }
+          "200": {
+            "$ref": "#/components/responses/updateTableRowsResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/updateTableRowsResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/updateTableRowsBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/updateTableRowsBody"
+        }
       }
     },
     "/v1/tables/{table}/rows/delete": {
@@ -307,14 +435,22 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/deleteTableRowsResponse" },
-          "default": { "$ref": "#/components/responses/deleteTableRowsResponse" }
+          "200": {
+            "$ref": "#/components/responses/deleteTableRowsResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/deleteTableRowsResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/deleteTableRowsBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/deleteTableRowsBody"
+        }
       }
     },
     "/v1/tables/{table}/rows/upsert": {
@@ -327,23 +463,48 @@
             "in": "path",
             "description": "The table's name or unique identifier for targeting specific table operations.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "$ref": "#/components/responses/upsertTableRowsResponse" },
-          "default": { "$ref": "#/components/responses/upsertTableRowsResponse" }
+          "200": {
+            "$ref": "#/components/responses/upsertTableRowsResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/upsertTableRowsResponse"
+          }
         },
-        "requestBody": { "$ref": "#/components/requestBodies/upsertTableRowsBody" }
+        "requestBody": {
+          "$ref": "#/components/requestBodies/upsertTableRowsBody"
+        }
       }
     }
   },
   "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "BotIdHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-bot-id",
+        "description": "Your bot ID."
+      }
+    },
     "schemas": {
       "Bot": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "minLength": 28, "maxLength": 36, "description": "Id of the [Bot](#schema_bot)" },
+          "id": {
+            "type": "string",
+            "minLength": 28,
+            "maxLength": 36,
+            "description": "Id of the [Bot](#schema_bot)"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -364,7 +525,9 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "enabled": { "type": "boolean" },
+                "enabled": {
+                  "type": "boolean"
+                },
                 "name": {
                   "type": "string",
                   "maxLength": 200,
@@ -375,11 +538,27 @@
                   "maxLength": 200,
                   "description": "Version of the [Integration](#schema_integration)"
                 },
-                "webhookUrl": { "type": "string", "maxLength": 2000 },
-                "webhookId": { "type": "string", "maxLength": 200 },
-                "identifier": { "type": "string", "maxLength": 2000 },
-                "configurationType": { "type": "string", "maxLength": 200, "nullable": true },
-                "configuration": { "type": "object", "additionalProperties": true },
+                "webhookUrl": {
+                  "type": "string",
+                  "maxLength": 2000
+                },
+                "webhookId": {
+                  "type": "string",
+                  "maxLength": 200
+                },
+                "identifier": {
+                  "type": "string",
+                  "maxLength": 2000
+                },
+                "configurationType": {
+                  "type": "string",
+                  "maxLength": 200,
+                  "nullable": true
+                },
+                "configuration": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
                 "status": {
                   "type": "string",
                   "enum": [
@@ -391,7 +570,11 @@
                     "unregistration_failed"
                   ]
                 },
-                "statusReason": { "type": "string", "maxLength": 2000, "nullable": true },
+                "statusReason": {
+                  "type": "string",
+                  "maxLength": 2000,
+                  "nullable": true
+                },
                 "id": {
                   "type": "string",
                   "minLength": 28,
@@ -429,7 +612,12 @@
                 },
                 "verificationStatus": {
                   "type": "string",
-                  "enum": ["unapproved", "pending", "approved", "rejected"],
+                  "enum": [
+                    "unapproved",
+                    "pending",
+                    "approved",
+                    "rejected"
+                  ],
                   "description": "Status of the integration version verification"
                 }
               },
@@ -464,15 +652,25 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
-                    "title": { "type": "string", "maxLength": 64, "description": "Title of the tag" },
-                    "description": { "type": "string", "maxLength": 256, "description": "Description of the tag" }
+                    "title": {
+                      "type": "string",
+                      "maxLength": 64,
+                      "description": "Title of the tag"
+                    },
+                    "description": {
+                      "type": "string",
+                      "maxLength": 256,
+                      "description": "Description of the tag"
+                    }
                   },
                   "description": "Definition of a tag that can be provided on the object",
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["tags"],
+            "required": [
+              "tags"
+            ],
             "description": "User object configuration",
             "additionalProperties": false
           },
@@ -484,15 +682,25 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
-                    "title": { "type": "string", "maxLength": 64, "description": "Title of the tag" },
-                    "description": { "type": "string", "maxLength": 256, "description": "Description of the tag" }
+                    "title": {
+                      "type": "string",
+                      "maxLength": 64,
+                      "description": "Title of the tag"
+                    },
+                    "description": {
+                      "type": "string",
+                      "maxLength": 256,
+                      "description": "Description of the tag"
+                    }
                   },
                   "description": "Definition of a tag that can be provided on the object",
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["tags"],
+            "required": [
+              "tags"
+            ],
             "description": "Conversation object configuration",
             "additionalProperties": false
           },
@@ -504,15 +712,25 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
-                    "title": { "type": "string", "maxLength": 64, "description": "Title of the tag" },
-                    "description": { "type": "string", "maxLength": 256, "description": "Description of the tag" }
+                    "title": {
+                      "type": "string",
+                      "maxLength": 64,
+                      "description": "Title of the tag"
+                    },
+                    "description": {
+                      "type": "string",
+                      "maxLength": 256,
+                      "description": "Description of the tag"
+                    }
                   },
                   "description": "Definition of a tag that can be provided on the object",
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["tags"],
+            "required": [
+              "tags"
+            ],
             "description": "Message object configuration",
             "additionalProperties": false
           },
@@ -523,7 +741,12 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["conversation", "user", "bot", "task"],
+                  "enum": [
+                    "conversation",
+                    "user",
+                    "bot",
+                    "task"
+                  ],
                   "description": "Type of the [State](#schema_state) (`conversation`, `user`, `bot` or `task`)"
                 },
                 "schema": {
@@ -537,7 +760,10 @@
                   "description": "Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."
                 }
               },
-              "required": ["type", "schema"],
+              "required": [
+                "type",
+                "schema"
+              ],
               "additionalProperties": false
             },
             "description": "A mapping of states to their definition"
@@ -545,14 +771,21 @@
           "configuration": {
             "type": "object",
             "properties": {
-              "data": { "type": "object", "additionalProperties": true, "description": "Configuration data" },
+              "data": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Configuration data"
+              },
               "schema": {
                 "type": "object",
                 "additionalProperties": true,
                 "description": "Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."
               }
             },
-            "required": ["data", "schema"],
+            "required": [
+              "data",
+              "schema"
+            ],
             "description": "Configuration of the bot",
             "additionalProperties": false
           },
@@ -561,11 +794,24 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the event" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the event" },
-                "schema": { "type": "object", "additionalProperties": true }
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the event"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the event"
+                },
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
               },
-              "required": ["schema"],
+              "required": [
+                "schema"
+              ],
               "description": "Event Definition",
               "additionalProperties": false
             },
@@ -578,12 +824,25 @@
               "properties": {
                 "schedule": {
                   "type": "object",
-                  "properties": { "cron": { "type": "string", "maxLength": 200 } },
-                  "required": ["cron"],
+                  "properties": {
+                    "cron": {
+                      "type": "string",
+                      "maxLength": 200
+                    }
+                  },
+                  "required": [
+                    "cron"
+                  ],
                   "additionalProperties": false
                 },
-                "type": { "type": "string", "maxLength": 200 },
-                "payload": { "type": "object", "additionalProperties": true },
+                "type": {
+                  "type": "string",
+                  "maxLength": 200
+                },
+                "payload": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
                 "failedAttempts": {
                   "type": "number",
                   "description": "The number of times the recurring event failed to run. This counter resets once the recurring event runs successfully."
@@ -595,7 +854,13 @@
                   "nullable": true
                 }
               },
-              "required": ["schedule", "type", "payload", "failedAttempts", "lastFailureReason"],
+              "required": [
+                "schedule",
+                "type",
+                "payload",
+                "failedAttempts",
+                "lastFailureReason"
+              ],
               "additionalProperties": false
             },
             "description": "Recurring events"
@@ -605,12 +870,17 @@
             "properties": {
               "events": {
                 "type": "object",
-                "additionalProperties": { "type": "object", "additionalProperties": false },
+                "additionalProperties": {
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "nullable": true,
                 "description": "Events that the bot is currently subscribed on (ex: \"slack:reactionAdded\"). If null, the bot is subscribed to all events."
               }
             },
-            "required": ["events"],
+            "required": [
+              "events"
+            ],
             "description": "Subscriptions of the bot",
             "additionalProperties": false
           },
@@ -619,24 +889,53 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the action" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the action" },
-                "billable": { "type": "boolean" },
-                "cacheable": { "type": "boolean" },
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the action"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the action"
+                },
+                "billable": {
+                  "type": "boolean"
+                },
+                "cacheable": {
+                  "type": "boolean"
+                },
                 "input": {
                   "type": "object",
-                  "properties": { "schema": { "type": "object", "additionalProperties": true } },
-                  "required": ["schema"],
+                  "properties": {
+                    "schema": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "required": [
+                    "schema"
+                  ],
                   "additionalProperties": false
                 },
                 "output": {
                   "type": "object",
-                  "properties": { "schema": { "type": "object", "additionalProperties": true } },
-                  "required": ["schema"],
+                  "properties": {
+                    "schema": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "required": [
+                    "schema"
+                  ],
                   "additionalProperties": false
                 }
               },
-              "required": ["input", "output"],
+              "required": [
+                "input",
+                "output"
+              ],
               "description": "Action definition",
               "additionalProperties": false
             },
@@ -644,10 +943,15 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Tags of [Bot](#schema_bot)"
           },
-          "name": { "type": "string", "description": "Name of the [Bot](#schema_bot)" },
+          "name": {
+            "type": "string",
+            "description": "Name of the [Bot](#schema_bot)"
+          },
           "deployedAt": {
             "type": "string",
             "format": "date-time",
@@ -657,21 +961,40 @@
             "type": "boolean",
             "description": "Indicates if the [Bot](#schema_bot) is a development bot; Development bots run locally and can install dev integrations"
           },
-          "createdBy": { "type": "string", "description": "Id of the user that created the bot" },
+          "createdBy": {
+            "type": "string",
+            "description": "Id of the user that created the bot"
+          },
           "alwaysAlive": {
             "type": "boolean",
             "description": "Indicates if the [Bot](#schema_bot) should be in always alive mode"
           },
-          "status": { "type": "string", "enum": ["active", "deploying"], "description": "Status of the bot" },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "deploying"
+            ],
+            "description": "Status of the bot"
+          },
           "medias": {
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
-                "url": { "type": "string", "description": "URL of the media file" },
-                "name": { "type": "string", "description": "Name of the media file" }
+                "url": {
+                  "type": "string",
+                  "description": "URL of the media file"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the media file"
+                }
               },
-              "required": ["url", "name"]
+              "required": [
+                "url",
+                "name"
+              ]
             },
             "description": "Media files associated with the [Bot](#schema_bot)"
           }
@@ -772,15 +1095,35 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "id": { "type": "string", "minLength": 28, "maxLength": 36, "description": "ID of the interface" },
-                "name": { "type": "string", "maxLength": 200, "description": "Name of the interface" },
-                "version": { "type": "string", "maxLength": 200, "description": "Version of the interface" },
+                "id": {
+                  "type": "string",
+                  "minLength": 28,
+                  "maxLength": 36,
+                  "description": "ID of the interface"
+                },
+                "name": {
+                  "type": "string",
+                  "maxLength": 200,
+                  "description": "Name of the interface"
+                },
+                "version": {
+                  "type": "string",
+                  "maxLength": 200,
+                  "description": "Version of the interface"
+                },
                 "entities": {
                   "type": "object",
                   "additionalProperties": {
                     "type": "object",
-                    "properties": { "name": { "type": "string", "maxLength": 200 } },
-                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 200
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false
                   }
                 },
@@ -788,8 +1131,15 @@
                   "type": "object",
                   "additionalProperties": {
                     "type": "object",
-                    "properties": { "name": { "type": "string", "maxLength": 200 } },
-                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 200
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false
                   }
                 },
@@ -797,8 +1147,15 @@
                   "type": "object",
                   "additionalProperties": {
                     "type": "object",
-                    "properties": { "name": { "type": "string", "maxLength": 200 } },
-                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 200
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false
                   }
                 },
@@ -806,28 +1163,58 @@
                   "type": "object",
                   "additionalProperties": {
                     "type": "object",
-                    "properties": { "name": { "type": "string", "maxLength": 200 } },
-                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 200
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false
                   }
                 }
               },
-              "required": ["id", "name", "version", "entities", "actions", "events", "channels"],
+              "required": [
+                "id",
+                "name",
+                "version",
+                "entities",
+                "actions",
+                "events",
+                "channels"
+              ],
               "additionalProperties": false
             }
           },
           "configuration": {
             "type": "object",
             "properties": {
-              "title": { "type": "string", "maxLength": 64, "description": "Title of the configuration" },
-              "description": { "type": "string", "maxLength": 256, "description": "Description of the configuration" },
+              "title": {
+                "type": "string",
+                "maxLength": 64,
+                "description": "Title of the configuration"
+              },
+              "description": {
+                "type": "string",
+                "maxLength": 256,
+                "description": "Description of the configuration"
+              },
               "identifier": {
                 "type": "object",
                 "properties": {
-                  "linkTemplateScript": { "type": "string", "maxLength": 2000 },
-                  "required": { "type": "boolean" }
+                  "linkTemplateScript": {
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "required": {
+                    "type": "boolean"
+                  }
                 },
-                "required": ["required"],
+                "required": [
+                  "required"
+                ],
                 "description": "Identifier configuration of the [Integration](#schema_integration)",
                 "additionalProperties": false
               },
@@ -837,7 +1224,10 @@
                 "description": "Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."
               }
             },
-            "required": ["identifier", "schema"],
+            "required": [
+              "identifier",
+              "schema"
+            ],
             "description": "Configuration definition",
             "additionalProperties": false
           },
@@ -846,7 +1236,11 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the configuration" },
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the configuration"
+                },
                 "description": {
                   "type": "string",
                   "maxLength": 256,
@@ -855,10 +1249,17 @@
                 "identifier": {
                   "type": "object",
                   "properties": {
-                    "linkTemplateScript": { "type": "string", "maxLength": 2000 },
-                    "required": { "type": "boolean" }
+                    "linkTemplateScript": {
+                      "type": "string",
+                      "maxLength": 2000
+                    },
+                    "required": {
+                      "type": "boolean"
+                    }
                   },
-                  "required": ["required"],
+                  "required": [
+                    "required"
+                  ],
                   "description": "Identifier configuration of the [Integration](#schema_integration)",
                   "additionalProperties": false
                 },
@@ -868,7 +1269,10 @@
                   "description": "Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."
                 }
               },
-              "required": ["identifier", "schema"],
+              "required": [
+                "identifier",
+                "schema"
+              ],
               "description": "Configuration definition",
               "additionalProperties": false
             }
@@ -878,14 +1282,29 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the channel" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the channel" },
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the channel"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the channel"
+                },
                 "messages": {
                   "type": "object",
                   "additionalProperties": {
                     "type": "object",
-                    "properties": { "schema": { "type": "object", "additionalProperties": true } },
-                    "required": ["schema"],
+                    "properties": {
+                      "schema": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "required": [
+                      "schema"
+                    ],
                     "description": "Message definition",
                     "additionalProperties": false
                   }
@@ -898,8 +1317,16 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
-                          "title": { "type": "string", "maxLength": 64, "description": "Title of the tag" },
-                          "description": { "type": "string", "maxLength": 256, "description": "Description of the tag" }
+                          "title": {
+                            "type": "string",
+                            "maxLength": 64,
+                            "description": "Title of the tag"
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 256,
+                            "description": "Description of the tag"
+                          }
                         },
                         "description": "Definition of a tag that can be provided on the object",
                         "additionalProperties": false
@@ -908,19 +1335,30 @@
                     "creation": {
                       "type": "object",
                       "properties": {
-                        "enabled": { "type": "boolean", "description": "Enable conversation creation" },
+                        "enabled": {
+                          "type": "boolean",
+                          "description": "Enable conversation creation"
+                        },
                         "requiredTags": {
                           "type": "array",
-                          "items": { "type": "string" },
+                          "items": {
+                            "type": "string"
+                          },
                           "description": "The list of tags that are required to be specified when calling the API directly to create a conversation."
                         }
                       },
-                      "required": ["enabled", "requiredTags"],
+                      "required": [
+                        "enabled",
+                        "requiredTags"
+                      ],
                       "description": "The conversation creation setting determines how to create a conversation through the API directly. The integration will have to implement the `createConversation` functionality to support this setting.",
                       "additionalProperties": false
                     }
                   },
-                  "required": ["tags", "creation"],
+                  "required": [
+                    "tags",
+                    "creation"
+                  ],
                   "description": "Conversation object configuration",
                   "additionalProperties": false
                 },
@@ -932,20 +1370,34 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
-                          "title": { "type": "string", "maxLength": 64, "description": "Title of the tag" },
-                          "description": { "type": "string", "maxLength": 256, "description": "Description of the tag" }
+                          "title": {
+                            "type": "string",
+                            "maxLength": 64,
+                            "description": "Title of the tag"
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 256,
+                            "description": "Description of the tag"
+                          }
                         },
                         "description": "Definition of a tag that can be provided on the object",
                         "additionalProperties": false
                       }
                     }
                   },
-                  "required": ["tags"],
+                  "required": [
+                    "tags"
+                  ],
                   "description": "Message object configuration",
                   "additionalProperties": false
                 }
               },
-              "required": ["messages", "conversation", "message"],
+              "required": [
+                "messages",
+                "conversation",
+                "message"
+              ],
               "description": "Channel definition",
               "additionalProperties": false
             }
@@ -957,7 +1409,11 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["conversation", "user", "integration"],
+                  "enum": [
+                    "conversation",
+                    "user",
+                    "integration"
+                  ],
                   "description": "Type of the [State](#schema_state) (`conversation`, `user` or `integration`)"
                 },
                 "schema": {
@@ -966,7 +1422,10 @@
                   "description": "Schema of the [State](#schema_state) in the `JSON schema` format. This `JSON schema` is going to be used for validating the state data."
                 }
               },
-              "required": ["type", "schema"],
+              "required": [
+                "type",
+                "schema"
+              ],
               "description": "State definition",
               "additionalProperties": false
             }
@@ -976,11 +1435,24 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the event" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the event" },
-                "schema": { "type": "object", "additionalProperties": true }
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the event"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the event"
+                },
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
               },
-              "required": ["schema"],
+              "required": [
+                "schema"
+              ],
               "description": "Event Definition",
               "additionalProperties": false
             }
@@ -990,24 +1462,53 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the action" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the action" },
-                "billable": { "type": "boolean" },
-                "cacheable": { "type": "boolean" },
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the action"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the action"
+                },
+                "billable": {
+                  "type": "boolean"
+                },
+                "cacheable": {
+                  "type": "boolean"
+                },
                 "input": {
                   "type": "object",
-                  "properties": { "schema": { "type": "object", "additionalProperties": true } },
-                  "required": ["schema"],
+                  "properties": {
+                    "schema": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "required": [
+                    "schema"
+                  ],
                   "additionalProperties": false
                 },
                 "output": {
                   "type": "object",
-                  "properties": { "schema": { "type": "object", "additionalProperties": true } },
-                  "required": ["schema"],
+                  "properties": {
+                    "schema": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "required": [
+                    "schema"
+                  ],
                   "additionalProperties": false
                 }
               },
-              "required": ["input", "output"],
+              "required": [
+                "input",
+                "output"
+              ],
               "description": "Action definition",
               "additionalProperties": false
             }
@@ -1020,8 +1521,16 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
-                    "title": { "type": "string", "maxLength": 64, "description": "Title of the tag" },
-                    "description": { "type": "string", "maxLength": 256, "description": "Description of the tag" }
+                    "title": {
+                      "type": "string",
+                      "maxLength": 64,
+                      "description": "Title of the tag"
+                    },
+                    "description": {
+                      "type": "string",
+                      "maxLength": 256,
+                      "description": "Description of the tag"
+                    }
                   },
                   "description": "Definition of a tag that can be provided on the object",
                   "additionalProperties": false
@@ -1030,19 +1539,30 @@
               "creation": {
                 "type": "object",
                 "properties": {
-                  "enabled": { "type": "boolean", "description": "Enable user creation" },
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "Enable user creation"
+                  },
                   "requiredTags": {
                     "type": "array",
-                    "items": { "type": "string" },
+                    "items": {
+                      "type": "string"
+                    },
                     "description": "The list of tags that are required to be specified when calling the API directly to create a user."
                   }
                 },
-                "required": ["enabled", "requiredTags"],
+                "required": [
+                  "enabled",
+                  "requiredTags"
+                ],
                 "description": "The user creation setting determines how to create a user through the API directly. The integration will have to implement the `createUser` functionality to support this setting.",
                 "additionalProperties": false
               }
             },
-            "required": ["tags", "creation"],
+            "required": [
+              "tags",
+              "creation"
+            ],
             "description": "User object configuration",
             "additionalProperties": false
           },
@@ -1051,11 +1571,24 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the entity" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the entity" },
-                "schema": { "type": "object", "additionalProperties": true }
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the entity"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the entity"
+                },
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
               },
-              "required": ["schema"],
+              "required": [
+                "schema"
+              ],
               "description": "Entity definition",
               "additionalProperties": false
             }
@@ -1089,12 +1622,19 @@
           },
           "verificationStatus": {
             "type": "string",
-            "enum": ["unapproved", "pending", "approved", "rejected"],
+            "enum": [
+              "unapproved",
+              "pending",
+              "approved",
+              "rejected"
+            ],
             "description": "Status of the integration version verification"
           },
           "secrets": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "Secrets are integration-wide values available in the code via environment variables formatted with a SECRET_ prefix followed by your secret name. A secret name must respect SCREAMING_SNAKE casing."
           }
         },
@@ -1145,7 +1685,11 @@
             "format": "date-time",
             "description": "Updating date of the [Interface](#schema_interface) in ISO 8601 format"
           },
-          "name": { "type": "string", "maxLength": 200, "description": "Name of the [Interface](#schema_interface)" },
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "Name of the [Interface](#schema_interface)"
+          },
           "version": {
             "type": "string",
             "maxLength": 200,
@@ -1156,11 +1700,24 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the entity" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the entity" },
-                "schema": { "type": "object", "additionalProperties": true }
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the entity"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the entity"
+                },
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
               },
-              "required": ["schema"],
+              "required": [
+                "schema"
+              ],
               "description": "Entity definition",
               "additionalProperties": false
             }
@@ -1170,11 +1727,24 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the event" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the event" },
-                "schema": { "type": "object", "additionalProperties": true }
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the event"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the event"
+                },
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
               },
-              "required": ["schema"],
+              "required": [
+                "schema"
+              ],
               "description": "Event Definition",
               "additionalProperties": false
             }
@@ -1184,24 +1754,53 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the action" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the action" },
-                "billable": { "type": "boolean" },
-                "cacheable": { "type": "boolean" },
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the action"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the action"
+                },
+                "billable": {
+                  "type": "boolean"
+                },
+                "cacheable": {
+                  "type": "boolean"
+                },
                 "input": {
                   "type": "object",
-                  "properties": { "schema": { "type": "object", "additionalProperties": true } },
-                  "required": ["schema"],
+                  "properties": {
+                    "schema": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "required": [
+                    "schema"
+                  ],
                   "additionalProperties": false
                 },
                 "output": {
                   "type": "object",
-                  "properties": { "schema": { "type": "object", "additionalProperties": true } },
-                  "required": ["schema"],
+                  "properties": {
+                    "schema": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "required": [
+                    "schema"
+                  ],
                   "additionalProperties": false
                 }
               },
-              "required": ["input", "output"],
+              "required": [
+                "input",
+                "output"
+              ],
               "description": "Action definition",
               "additionalProperties": false
             }
@@ -1211,35 +1810,71 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the channel" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the channel" },
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the channel"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the channel"
+                },
                 "messages": {
                   "type": "object",
                   "additionalProperties": {
                     "type": "object",
-                    "properties": { "schema": { "type": "object", "additionalProperties": true } },
-                    "required": ["schema"],
+                    "properties": {
+                      "schema": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "required": [
+                      "schema"
+                    ],
                     "description": "Message definition",
                     "additionalProperties": false
                   }
                 }
               },
-              "required": ["messages"],
+              "required": [
+                "messages"
+              ],
               "additionalProperties": false
             }
           },
           "nameTemplate": {
             "type": "object",
             "properties": {
-              "script": { "type": "string", "maxLength": 2000 },
-              "language": { "type": "string", "maxLength": 200 }
+              "script": {
+                "type": "string",
+                "maxLength": 2000
+              },
+              "language": {
+                "type": "string",
+                "maxLength": 200
+              }
             },
-            "required": ["script", "language"],
+            "required": [
+              "script",
+              "language"
+            ],
             "description": "Template string optionaly used at build time by integrations implementing this interface to pick a name for actions and events.",
             "additionalProperties": false
           }
         },
-        "required": ["id", "createdAt", "updatedAt", "name", "version", "entities", "events", "actions", "channels"],
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt",
+          "name",
+          "version",
+          "entities",
+          "events",
+          "actions",
+          "channels"
+        ],
         "additionalProperties": false
       },
       "Plugin": {
@@ -1251,8 +1886,16 @@
             "maxLength": 36,
             "description": "ID of the [Plugin](#schema_plugin)"
           },
-          "name": { "type": "string", "maxLength": 200, "description": "Name of the [Plugin](#schema_plugin)" },
-          "version": { "type": "string", "maxLength": 200, "description": "Version of the [Plugin](#schema_plugin)" },
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "Name of the [Plugin](#schema_plugin)"
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "Version of the [Plugin](#schema_plugin)"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -1266,15 +1909,25 @@
           "configuration": {
             "type": "object",
             "properties": {
-              "title": { "type": "string", "maxLength": 64, "description": "Title of the configuration" },
-              "description": { "type": "string", "maxLength": 256, "description": "Description of the configuration" },
+              "title": {
+                "type": "string",
+                "maxLength": 64,
+                "description": "Title of the configuration"
+              },
+              "description": {
+                "type": "string",
+                "maxLength": 256,
+                "description": "Description of the configuration"
+              },
               "schema": {
                 "type": "object",
                 "additionalProperties": true,
                 "description": "Schema of the configuration in the `JSON schema` format. The configuration data is validated against this `JSON schema`."
               }
             },
-            "required": ["schema"],
+            "required": [
+              "schema"
+            ],
             "description": "Configuration definition",
             "additionalProperties": false
           },
@@ -1285,7 +1938,12 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["conversation", "user", "bot", "task"],
+                  "enum": [
+                    "conversation",
+                    "user",
+                    "bot",
+                    "task"
+                  ],
                   "description": "Type of the [State](#schema_state) (`conversation`, `user`, `bot` or `task`)"
                 },
                 "schema": {
@@ -1299,7 +1957,10 @@
                   "description": "Expiry of the [State](#schema_state) in milliseconds. The state will expire if it is idle for the configured value. By default, a state doesn't expire."
                 }
               },
-              "required": ["type", "schema"],
+              "required": [
+                "type",
+                "schema"
+              ],
               "additionalProperties": false
             }
           },
@@ -1308,11 +1969,24 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the event" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the event" },
-                "schema": { "type": "object", "additionalProperties": true }
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the event"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the event"
+                },
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
               },
-              "required": ["schema"],
+              "required": [
+                "schema"
+              ],
               "description": "Event Definition",
               "additionalProperties": false
             }
@@ -1322,24 +1996,53 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "title": { "type": "string", "maxLength": 64, "description": "Title of the action" },
-                "description": { "type": "string", "maxLength": 256, "description": "Description of the action" },
-                "billable": { "type": "boolean" },
-                "cacheable": { "type": "boolean" },
+                "title": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Title of the action"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 256,
+                  "description": "Description of the action"
+                },
+                "billable": {
+                  "type": "boolean"
+                },
+                "cacheable": {
+                  "type": "boolean"
+                },
                 "input": {
                   "type": "object",
-                  "properties": { "schema": { "type": "object", "additionalProperties": true } },
-                  "required": ["schema"],
+                  "properties": {
+                    "schema": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "required": [
+                    "schema"
+                  ],
                   "additionalProperties": false
                 },
                 "output": {
                   "type": "object",
-                  "properties": { "schema": { "type": "object", "additionalProperties": true } },
-                  "required": ["schema"],
+                  "properties": {
+                    "schema": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "required": [
+                    "schema"
+                  ],
                   "additionalProperties": false
                 }
               },
-              "required": ["input", "output"],
+              "required": [
+                "input",
+                "output"
+              ],
               "description": "Action definition",
               "additionalProperties": false
             }
@@ -1352,11 +2055,25 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string", "minLength": 28, "maxLength": 36 },
-                    "name": { "type": "string", "maxLength": 200 },
-                    "version": { "type": "string", "maxLength": 200 }
+                    "id": {
+                      "type": "string",
+                      "minLength": 28,
+                      "maxLength": 36
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 200
+                    },
+                    "version": {
+                      "type": "string",
+                      "maxLength": 200
+                    }
                   },
-                  "required": ["id", "name", "version"],
+                  "required": [
+                    "id",
+                    "name",
+                    "version"
+                  ],
                   "additionalProperties": false
                 }
               },
@@ -1365,16 +2082,33 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string", "minLength": 28, "maxLength": 36 },
-                    "name": { "type": "string", "maxLength": 200 },
-                    "version": { "type": "string", "maxLength": 200 }
+                    "id": {
+                      "type": "string",
+                      "minLength": 28,
+                      "maxLength": 36
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 200
+                    },
+                    "version": {
+                      "type": "string",
+                      "maxLength": 200
+                    }
                   },
-                  "required": ["id", "name", "version"],
+                  "required": [
+                    "id",
+                    "name",
+                    "version"
+                  ],
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["interfaces", "integrations"],
+            "required": [
+              "interfaces",
+              "integrations"
+            ],
             "additionalProperties": false
           },
           "user": {
@@ -1385,15 +2119,25 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
-                    "title": { "type": "string", "maxLength": 64, "description": "Title of the tag" },
-                    "description": { "type": "string", "maxLength": 256, "description": "Description of the tag" }
+                    "title": {
+                      "type": "string",
+                      "maxLength": 64,
+                      "description": "Title of the tag"
+                    },
+                    "description": {
+                      "type": "string",
+                      "maxLength": 256,
+                      "description": "Description of the tag"
+                    }
                   },
                   "description": "Definition of a tag that can be provided on the object",
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["tags"],
+            "required": [
+              "tags"
+            ],
             "description": "User object configuration",
             "additionalProperties": false
           },
@@ -1405,15 +2149,25 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
-                    "title": { "type": "string", "maxLength": 64, "description": "Title of the tag" },
-                    "description": { "type": "string", "maxLength": 256, "description": "Description of the tag" }
+                    "title": {
+                      "type": "string",
+                      "maxLength": 64,
+                      "description": "Title of the tag"
+                    },
+                    "description": {
+                      "type": "string",
+                      "maxLength": 256,
+                      "description": "Description of the tag"
+                    }
                   },
                   "description": "Definition of a tag that can be provided on the object",
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["tags"],
+            "required": [
+              "tags"
+            ],
             "description": "Conversation object configuration",
             "additionalProperties": false
           },
@@ -1460,23 +2214,77 @@
       "Workspace": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string" },
-          "ownerId": { "type": "string" },
-          "createdAt": { "type": "string" },
-          "updatedAt": { "type": "string" },
-          "botCount": { "type": "number" },
-          "billingVersion": { "type": "string", "enum": ["v1", "v2", "v3"] },
-          "plan": { "type": "string", "enum": ["community", "team", "enterprise", "plus"] },
-          "blocked": { "type": "boolean" },
-          "spendingLimit": { "type": "number" },
-          "about": { "default": "", "type": "string" },
-          "profilePicture": { "default": "", "type": "string" },
-          "contactEmail": { "default": "", "type": "string" },
-          "website": { "default": "", "type": "string" },
-          "socialAccounts": { "default": [], "type": "array", "items": { "type": "string" } },
-          "isPublic": { "type": "boolean" },
-          "handle": { "default": "", "type": "string" }
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ownerId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "botCount": {
+            "type": "number"
+          },
+          "billingVersion": {
+            "type": "string",
+            "enum": [
+              "v1",
+              "v2",
+              "v3"
+            ]
+          },
+          "plan": {
+            "type": "string",
+            "enum": [
+              "community",
+              "team",
+              "enterprise",
+              "plus"
+            ]
+          },
+          "blocked": {
+            "type": "boolean"
+          },
+          "spendingLimit": {
+            "type": "number"
+          },
+          "about": {
+            "default": "",
+            "type": "string"
+          },
+          "profilePicture": {
+            "default": "",
+            "type": "string"
+          },
+          "contactEmail": {
+            "default": "",
+            "type": "string"
+          },
+          "website": {
+            "default": "",
+            "type": "string"
+          },
+          "socialAccounts": {
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "handle": {
+            "default": "",
+            "type": "string"
+          }
         },
         "required": [
           "id",
@@ -1496,33 +2304,78 @@
       "WorkspaceMember": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "userId": { "type": "string", "format": "uuid" },
-          "email": { "type": "string" },
-          "createdAt": { "type": "string" },
-          "role": { "type": "string", "enum": ["viewer", "billing", "developer", "manager", "administrator", "owner"] },
-          "profilePicture": { "type": "string" },
-          "displayName": { "type": "string", "maxLength": 100 }
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "viewer",
+              "billing",
+              "developer",
+              "manager",
+              "administrator",
+              "owner"
+            ]
+          },
+          "profilePicture": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string",
+            "maxLength": 100
+          }
         },
-        "required": ["id", "email", "createdAt", "role"],
+        "required": [
+          "id",
+          "email",
+          "createdAt",
+          "role"
+        ],
         "title": "updateWorkspaceMemberResponse",
         "additionalProperties": false
       },
       "Account": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "email": { "type": "string" },
-          "displayName": { "type": "string", "maxLength": 100 },
-          "emailVerified": { "type": "boolean" },
-          "profilePicture": { "type": "string" },
+          "id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "emailVerified": {
+            "type": "boolean"
+          },
+          "profilePicture": {
+            "type": "string"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
             "description": "Creation date of the [Account](#schema_account) in ISO 8601 format"
           }
         },
-        "required": ["id", "email", "emailVerified", "createdAt"],
+        "required": [
+          "id",
+          "email",
+          "emailVerified",
+          "createdAt"
+        ],
         "additionalProperties": false
       },
       "Usage": {
@@ -1532,9 +2385,18 @@
             "type": "string",
             "description": "Id of the usage that it is linked to. It can either be a workspace id or a bot id"
           },
-          "period": { "type": "string", "description": "Period of the quota that it is applied to" },
-          "value": { "type": "number", "description": "Value of the current usage" },
-          "quota": { "type": "number", "description": "Quota of the current usage" },
+          "period": {
+            "type": "string",
+            "description": "Period of the quota that it is applied to"
+          },
+          "value": {
+            "type": "number",
+            "description": "Value of the current usage"
+          },
+          "quota": {
+            "type": "number",
+            "description": "Quota of the current usage"
+          },
           "type": {
             "type": "string",
             "enum": [
@@ -1555,30 +2417,72 @@
             "description": "Usage type that can be used"
           }
         },
-        "required": ["id", "period", "value", "quota", "type"],
+        "required": [
+          "id",
+          "period",
+          "value",
+          "quota",
+          "type"
+        ],
         "additionalProperties": false
       },
       "Issue": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "code": { "type": "string" },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "lastSeenAt": { "type": "string", "format": "date-time" },
-          "title": { "type": "string" },
-          "description": { "type": "string" },
+          "id": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastSeenAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
           "groupedData": {
             "type": "object",
             "additionalProperties": {
               "type": "object",
-              "properties": { "raw": { "type": "string" }, "pretty": { "type": "string" } },
-              "required": ["raw"],
+              "properties": {
+                "raw": {
+                  "type": "string"
+                },
+                "pretty": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "raw"
+              ],
               "additionalProperties": false
             }
           },
-          "eventsCount": { "type": "number" },
-          "category": { "type": "string", "enum": ["user_code", "limits", "configuration", "other"] },
-          "resolutionLink": { "type": "string", "nullable": true }
+          "eventsCount": {
+            "type": "number"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "user_code",
+              "limits",
+              "configuration",
+              "other"
+            ]
+          },
+          "resolutionLink": {
+            "type": "string",
+            "nullable": true
+          }
         },
         "required": [
           "id",
@@ -1597,27 +2501,51 @@
       "IssueEvent": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "createdAt": { "type": "string", "format": "date-time" },
+          "id": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
           "data": {
             "type": "object",
             "additionalProperties": {
               "type": "object",
-              "properties": { "raw": { "type": "string" }, "pretty": { "type": "string" } },
-              "required": ["raw"],
+              "properties": {
+                "raw": {
+                  "type": "string"
+                },
+                "pretty": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "raw"
+              ],
               "additionalProperties": false
             }
           }
         },
-        "required": ["id", "createdAt", "data"],
+        "required": [
+          "id",
+          "createdAt",
+          "data"
+        ],
         "additionalProperties": false
       },
       "Activity": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "description": { "type": "string" },
-          "taskId": { "type": "string" },
+          "id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "taskId": {
+            "type": "string"
+          },
           "category": {
             "type": "string",
             "enum": [
@@ -1633,26 +2561,54 @@
               "exception"
             ]
           },
-          "data": { "type": "object", "additionalProperties": true },
+          "data": {
+            "type": "object",
+            "additionalProperties": true
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
             "description": "Creation date of the activity in ISO 8601 format"
           }
         },
-        "required": ["id", "description", "taskId", "category", "data", "createdAt"],
+        "required": [
+          "id",
+          "description",
+          "taskId",
+          "category",
+          "data",
+          "createdAt"
+        ],
         "additionalProperties": false
       },
       "Version": {
         "type": "object",
-        "properties": { "id": { "type": "string" }, "name": { "type": "string" }, "description": { "type": "string" } },
-        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
         "additionalProperties": false
       },
       "User": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "minLength": 28, "maxLength": 36, "description": "Id of the [User](#schema_user)" },
+          "id": {
+            "type": "string",
+            "minLength": 28,
+            "maxLength": 36,
+            "description": "Id of the [User](#schema_user)"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -1665,17 +2621,28 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [User](#schema_user). The set of [Tags](/docs/developers/concepts/tags) available on a [User](#schema_user) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."
           },
-          "name": { "type": "string", "maxLength": 200, "description": "Name of the [User](#schema_user)" },
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "Name of the [User](#schema_user)"
+          },
           "pictureUrl": {
             "type": "string",
             "maxLength": 40000,
             "description": "Picture URL of the [User](#schema_user)"
           }
         },
-        "required": ["id", "createdAt", "updatedAt", "tags"],
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt",
+          "tags"
+        ],
         "description": "The user object represents someone interacting with the bot within a specific integration. The same person interacting with a bot in slack and messenger will be represented with two different users.",
         "additionalProperties": false
       },
@@ -1720,11 +2687,20 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Conversation](#schema_conversation). The set of [Tags](/docs/developers/concepts/tags) available on a [Conversation](#schema_conversation) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."
           }
         },
-        "required": ["id", "createdAt", "updatedAt", "channel", "integration", "tags"],
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt",
+          "channel",
+          "integration",
+          "tags"
+        ],
         "description": "The [Conversation](#schema_conversation) object represents an exchange of messages between one or more users. A [Conversation](#schema_conversation) is always linked to an integration's channels. For example, a Slack channel represents a conversation.",
         "additionalProperties": false
       },
@@ -1742,7 +2718,11 @@
             "format": "date-time",
             "description": "Creation date of the [Event](#schema_event) in ISO 8601 format"
           },
-          "type": { "type": "string", "maxLength": 200, "description": "Type of the [Event](#schema_event)." },
+          "type": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "Type of the [Event](#schema_event)."
+          },
           "payload": {
             "type": "object",
             "additionalProperties": true,
@@ -1766,7 +2746,16 @@
             "maxLength": 36,
             "description": "ID of the [Message](#schema_message) to link the event to."
           },
-          "status": { "type": "string", "enum": ["pending", "processed", "ignored", "failed", "scheduled"] },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "processed",
+              "ignored",
+              "failed",
+              "scheduled"
+            ]
+          },
           "failureReason": {
             "type": "string",
             "maxLength": 2000,
@@ -1774,7 +2763,14 @@
             "description": "Reason why the event failed to be processed"
           }
         },
-        "required": ["id", "createdAt", "type", "payload", "status", "failureReason"],
+        "required": [
+          "id",
+          "createdAt",
+          "type",
+          "payload",
+          "status",
+          "failureReason"
+        ],
         "description": "The event object represents an action or an occurrence.",
         "additionalProperties": false
       },
@@ -1809,7 +2805,10 @@
           },
           "direction": {
             "type": "string",
-            "enum": ["incoming", "outgoing"],
+            "enum": [
+              "incoming",
+              "outgoing"
+            ],
             "description": "Direction of the message (`incoming` or `outgoing`)."
           },
           "userId": {
@@ -1826,7 +2825,9 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Conversation](#schema_conversation). The set of [Tags](/docs/developers/concepts/tags) available on a [Conversation](#schema_conversation) is restricted by the list of [Tags](/docs/developers/concepts/tags) defined previously by the [Bot](#schema_bot). Individual keys can be unset by posting an empty value to them."
           }
         },
@@ -1888,7 +2889,14 @@
           },
           "type": {
             "type": "string",
-            "enum": ["conversation", "user", "bot", "task", "integration", "workflow"],
+            "enum": [
+              "conversation",
+              "user",
+              "bot",
+              "task",
+              "integration",
+              "workflow"
+            ],
             "description": "Type of the [State](#schema_state) represents the resource type (`conversation`, `user`, `bot`, `task`, `integration` or `workflow`) that the state is related to"
           },
           "payload": {
@@ -1897,25 +2905,58 @@
             "description": "Payload is the content of the state defined by your bot."
           }
         },
-        "required": ["id", "createdAt", "updatedAt", "botId", "name", "type", "payload"],
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt",
+          "botId",
+          "name",
+          "type",
+          "payload"
+        ],
         "description": "The state object represents the current payload. A state is always linked to either a bot, a conversation or a user.",
         "additionalProperties": false
       },
       "Task": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "minLength": 28, "maxLength": 36, "description": "Id of the [Task](#schema_task)" },
-          "title": { "type": "string", "maxLength": 64, "description": "Title describing the task" },
+          "id": {
+            "type": "string",
+            "minLength": 28,
+            "maxLength": 36,
+            "description": "Id of the [Task](#schema_task)"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Title describing the task"
+          },
           "description": {
             "type": "string",
             "maxLength": 256,
             "description": "All the notes related to the execution of the current task"
           },
-          "type": { "type": "string", "description": "Type of the task" },
-          "data": { "type": "object", "additionalProperties": true, "description": "Content related to the task" },
+          "type": {
+            "type": "string",
+            "description": "Type of the task"
+          },
+          "data": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Content related to the task"
+          },
           "status": {
             "type": "string",
-            "enum": ["pending", "in_progress", "failed", "completed", "blocked", "paused", "timeout", "cancelled"],
+            "enum": [
+              "pending",
+              "in_progress",
+              "failed",
+              "completed",
+              "blocked",
+              "paused",
+              "timeout",
+              "cancelled"
+            ],
             "description": "Status of the task"
           },
           "parentTaskId": {
@@ -1958,7 +2999,9 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Task](#schema_task). Individual keys can be unset by posting an empty value to them."
           }
         },
@@ -1986,10 +3029,23 @@
             "maxLength": 36,
             "description": "Id of the [Workflow](#schema_workflow)"
           },
-          "name": { "type": "string", "maxLength": 200, "description": "Name of the workflow" },
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "Name of the workflow"
+          },
           "status": {
             "type": "string",
-            "enum": ["pending", "in_progress", "failed", "completed", "listening", "paused", "timedout", "cancelled"],
+            "enum": [
+              "pending",
+              "in_progress",
+              "failed",
+              "completed",
+              "listening",
+              "paused",
+              "timedout",
+              "cancelled"
+            ],
             "description": "Status of the [Workflow](#schema_workflow)"
           },
           "input": {
@@ -2047,18 +3103,33 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Set of [Tags](/docs/developers/concepts/tags) that you can attach to a [Workflow](#schema_workflow). Individual keys can be unset by posting an empty value to them."
           }
         },
-        "required": ["id", "name", "status", "input", "output", "createdAt", "updatedAt", "timeoutAt", "tags"],
+        "required": [
+          "id",
+          "name",
+          "status",
+          "input",
+          "output",
+          "createdAt",
+          "updatedAt",
+          "timeoutAt",
+          "tags"
+        ],
         "description": "Workflow definition",
         "additionalProperties": false
       },
       "Table": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "description": "Unique identifier for the table" },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the table"
+          },
           "name": {
             "description": "Required. This name is used to identify your table.",
             "type": "string",
@@ -2078,31 +3149,70 @@
           "schema": {
             "type": "object",
             "properties": {
-              "$schema": { "type": "string" },
+              "$schema": {
+                "type": "string"
+              },
               "properties": {
                 "type": "object",
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
-                    "type": { "type": "string", "enum": ["string", "number", "boolean", "object", "array", "null"] },
-                    "format": { "type": "string", "enum": ["date-time"] },
-                    "description": { "type": "string" },
-                    "pattern": { "type": "string", "description": "String properties must match this pattern" },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "string",
+                        "number",
+                        "boolean",
+                        "object",
+                        "array",
+                        "null"
+                      ]
+                    },
+                    "format": {
+                      "type": "string",
+                      "enum": [
+                        "date-time"
+                      ]
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "pattern": {
+                      "type": "string",
+                      "description": "String properties must match this pattern"
+                    },
                     "enum": {
                       "type": "array",
-                      "items": { "type": "string" },
+                      "items": {
+                        "type": "string"
+                      },
                       "description": "String properties must be one of these values"
                     },
                     "items": {
                       "type": "object",
                       "properties": {
-                        "type": { "type": "string", "enum": ["string", "number", "boolean", "object", "array", "null"] }
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "object",
+                            "array",
+                            "null"
+                          ]
+                        }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "additionalProperties": true,
                       "description": "Defines the shape of items in an array"
                     },
-                    "nullable": { "default": true, "type": "boolean" },
+                    "nullable": {
+                      "default": true,
+                      "type": "boolean"
+                    },
                     "properties": {
                       "type": "object",
                       "additionalProperties": {
@@ -2110,33 +3220,78 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": ["string", "number", "boolean", "object", "array", "null"]
+                            "enum": [
+                              "string",
+                              "number",
+                              "boolean",
+                              "object",
+                              "array",
+                              "null"
+                            ]
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "additionalProperties": true
                       }
                     },
                     "x-zui": {
                       "type": "object",
                       "properties": {
-                        "index": { "type": "integer" },
-                        "id": { "type": "string", "description": "[deprecated] ID of the column." },
+                        "index": {
+                          "type": "integer"
+                        },
+                        "id": {
+                          "type": "string",
+                          "description": "[deprecated] ID of the column."
+                        },
                         "searchable": {
                           "type": "boolean",
                           "description": "Indicates if the column is vectorized and searchable."
                         },
-                        "hidden": { "type": "boolean", "description": "Indicates if the field is hidden in the UI" },
-                        "order": { "type": "number", "description": "Order of the column in the UI" },
-                        "width": { "type": "number", "description": "Width of the column in the UI" },
-                        "schemaId": { "type": "string", "description": "ID of the schema" },
+                        "hidden": {
+                          "type": "boolean",
+                          "description": "Indicates if the field is hidden in the UI"
+                        },
+                        "order": {
+                          "type": "number",
+                          "description": "Order of the column in the UI"
+                        },
+                        "width": {
+                          "type": "number",
+                          "description": "Width of the column in the UI"
+                        },
+                        "schemaId": {
+                          "type": "string",
+                          "description": "ID of the schema"
+                        },
                         "computed": {
                           "type": "object",
                           "properties": {
-                            "action": { "type": "string", "enum": ["ai", "code", "workflow"] },
-                            "dependencies": { "default": [], "type": "array", "items": { "type": "string" } },
-                            "prompt": { "type": "string", "description": "Prompt when action is \"ai\"" },
-                            "code": { "type": "string", "description": "Code to execute when action is \"code\"" },
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "ai",
+                                "code",
+                                "workflow"
+                              ]
+                            },
+                            "dependencies": {
+                              "default": [],
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "prompt": {
+                              "type": "string",
+                              "description": "Prompt when action is \"ai\""
+                            },
+                            "code": {
+                              "type": "string",
+                              "description": "Code to execute when action is \"code\""
+                            },
                             "model": {
                               "default": "gpt-4o",
                               "type": "string",
@@ -2148,9 +3303,13 @@
                               "maxLength": 20,
                               "description": "ID of Workflow to execute when action is \"workflow\""
                             },
-                            "enabled": { "type": "boolean" }
+                            "enabled": {
+                              "type": "boolean"
+                            }
                           },
-                          "required": ["action"],
+                          "required": [
+                            "action"
+                          ],
                           "additionalProperties": false
                         },
                         "typings": {
@@ -2158,60 +3317,107 @@
                           "description": "TypeScript typings for the column. Recommended if the type is \"object\", ex: \"\\{ foo: string; bar: number \\}\""
                         }
                       },
-                      "required": ["index"],
+                      "required": [
+                        "index"
+                      ],
                       "additionalProperties": false
                     }
                   },
-                  "required": ["type", "x-zui"],
+                  "required": [
+                    "type",
+                    "x-zui"
+                  ],
                   "additionalProperties": false
                 },
                 "description": "List of keys/columns in the table."
               },
               "additionalProperties": {
                 "type": "boolean",
-                "enum": [true],
+                "enum": [
+                  true
+                ],
                 "description": "Additional properties can be provided, but they will be ignored if no column matches."
               },
               "required": {
                 "type": "array",
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "description": "Array of required properties."
               },
-              "type": { "type": "string", "enum": ["object"] }
+              "type": {
+                "type": "string",
+                "enum": [
+                  "object"
+                ]
+              }
             },
-            "required": ["properties", "additionalProperties", "type"],
+            "required": [
+              "properties",
+              "additionalProperties",
+              "type"
+            ],
             "additionalProperties": false
           },
           "tags": {
             "type": "object",
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Optional tags to help organize your tables. These should be passed here as an object representing key/value pairs."
           },
           "isComputeEnabled": {
             "type": "boolean",
             "description": "Indicates if the table is enabled for computation."
           },
-          "createdAt": { "type": "string", "format": "date-time", "description": "Timestamp of table creation." },
-          "updatedAt": { "type": "string", "format": "date-time", "description": "Timestamp of the last table update." }
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of table creation."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the last table update."
+          }
         },
-        "required": ["id", "name", "schema"],
+        "required": [
+          "id",
+          "name",
+          "schema"
+        ],
         "additionalProperties": false
       },
       "Column": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "description": "Unique identifier for the column." },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the column."
+          },
           "name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
             "description": "Name of the column, must be within length limits."
           },
-          "description": { "type": "string", "description": "Optional descriptive text about the column." },
-          "searchable": { "type": "boolean", "description": "Indicates if the column is vectorized and searchable." },
+          "description": {
+            "type": "string",
+            "description": "Optional descriptive text about the column."
+          },
+          "searchable": {
+            "type": "boolean",
+            "description": "Indicates if the column is vectorized and searchable."
+          },
           "type": {
             "type": "string",
-            "enum": ["string", "number", "boolean", "date", "object"],
+            "enum": [
+              "string",
+              "number",
+              "boolean",
+              "date",
+              "object"
+            ],
             "description": "Specifies the data type of the column. Use \"object\" for complex data structures."
           },
           "typings": {
@@ -2221,10 +3427,29 @@
           "computed": {
             "type": "object",
             "properties": {
-              "action": { "type": "string", "enum": ["ai", "code", "workflow"] },
-              "dependencies": { "default": [], "type": "array", "items": { "type": "string" } },
-              "prompt": { "type": "string", "description": "Prompt when action is \"ai\"" },
-              "code": { "type": "string", "description": "Code to execute when action is \"code\"" },
+              "action": {
+                "type": "string",
+                "enum": [
+                  "ai",
+                  "code",
+                  "workflow"
+                ]
+              },
+              "dependencies": {
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "prompt": {
+                "type": "string",
+                "description": "Prompt when action is \"ai\""
+              },
+              "code": {
+                "type": "string",
+                "description": "Code to execute when action is \"code\""
+              },
               "model": {
                 "default": "gpt-4o",
                 "type": "string",
@@ -2236,39 +3461,72 @@
                 "maxLength": 20,
                 "description": "ID of Workflow to execute when action is \"workflow\""
               },
-              "enabled": { "type": "boolean" }
+              "enabled": {
+                "type": "boolean"
+              }
             },
-            "required": ["action"],
+            "required": [
+              "action"
+            ],
             "additionalProperties": false
           },
-          "schema": { "type": "object", "additionalProperties": true }
+          "schema": {
+            "type": "object",
+            "additionalProperties": true
+          }
         },
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "additionalProperties": false
       },
       "Row": {
         "type": "object",
         "properties": {
-          "id": { "type": "number", "description": "Unique identifier for the row." },
-          "createdAt": { "type": "string", "format": "date-time", "description": "Timestamp of row creation." },
-          "updatedAt": { "type": "string", "format": "date-time", "description": "Timestamp of the last row update." },
+          "id": {
+            "type": "number",
+            "description": "Unique identifier for the row."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of row creation."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the last row update."
+          },
           "computed": {
             "type": "object",
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "status": { "type": "string" },
-                "error": { "type": "string" },
-                "updatedBy": { "type": "string" },
-                "updatedAt": { "type": "string" }
+                "status": {
+                  "type": "string"
+                },
+                "error": {
+                  "type": "string"
+                },
+                "updatedBy": {
+                  "type": "string"
+                },
+                "updatedAt": {
+                  "type": "string"
+                }
               },
-              "required": ["status"],
+              "required": [
+                "status"
+              ],
               "additionalProperties": false
             }
           },
           "stale": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "[Read-only] List of stale values that are waiting to be recomputed."
           },
           "similarity": {
@@ -2276,14 +3534,23 @@
             "description": "Optional numeric value indicating similarity, when using findTableRows."
           }
         },
-        "required": ["id", "computed"],
+        "required": [
+          "id",
+          "computed"
+        ],
         "additionalProperties": true
       },
       "File": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "description": "File ID" },
-          "botId": { "type": "string", "description": "The ID of the bot the file belongs to" },
+          "id": {
+            "type": "string",
+            "description": "File ID"
+          },
+          "botId": {
+            "type": "string",
+            "description": "The ID of the bot the file belongs to"
+          },
           "key": {
             "type": "string",
             "description": "Unique key for the file. Must be unique across the bot (and the integration, when applicable)."
@@ -2297,22 +3564,42 @@
             "description": "File size in bytes. Non-null if file upload status is \"COMPLETE\".",
             "nullable": true
           },
-          "contentType": { "type": "string", "description": "MIME type of the file's content" },
+          "contentType": {
+            "type": "string",
+            "description": "MIME type of the file's content"
+          },
           "tags": {
             "type": "object",
-            "additionalProperties": { "type": "string", "maxLength": 1000 },
+            "additionalProperties": {
+              "type": "string",
+              "maxLength": 1000
+            },
             "description": "The tags of the file as an object of key/value pairs"
           },
           "metadata": {
             "type": "object",
-            "additionalProperties": { "nullable": true },
+            "additionalProperties": {
+              "nullable": true
+            },
             "description": "Metadata of the file as an object of key/value pairs. The values can be of any type."
           },
-          "createdAt": { "type": "string", "description": "File creation timestamp in ISO 8601 format" },
-          "updatedAt": { "type": "string", "description": "File last update timestamp in ISO 8601 format" },
+          "createdAt": {
+            "type": "string",
+            "description": "File creation timestamp in ISO 8601 format"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "File last update timestamp in ISO 8601 format"
+          },
           "accessPolicies": {
             "type": "array",
-            "items": { "type": "string", "enum": ["integrations", "public_content"] },
+            "items": {
+              "type": "string",
+              "enum": [
+                "integrations",
+                "public_content"
+              ]
+            },
             "description": "Access policies configured for the file."
           },
           "index": {
@@ -2335,7 +3622,10 @@
             "type": "string",
             "description": "If the file status is `upload_failed` or `indexing_failed` this will contain the reason of the failure."
           },
-          "expiresAt": { "type": "string", "description": "File expiry timestamp in ISO 8601 format" }
+          "expiresAt": {
+            "type": "string",
+            "description": "File expiry timestamp in ISO 8601 format"
+          }
         },
         "required": [
           "id",
@@ -2362,8 +3652,17 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "properties": { "tables": { "type": "array", "items": { "$ref": "#/components/schemas/Table" } } },
-              "required": ["tables"],
+              "properties": {
+                "tables": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Table"
+                  }
+                }
+              },
+              "required": [
+                "tables"
+              ],
               "title": "listTablesResponse",
               "additionalProperties": false
             }
@@ -2377,8 +3676,13 @@
             "schema": {
               "type": "object",
               "properties": {
-                "table": { "$ref": "#/components/schemas/Table" },
-                "rows": { "type": "number", "description": "The total number of rows present in the table." },
+                "table": {
+                  "$ref": "#/components/schemas/Table"
+                },
+                "rows": {
+                  "type": "number",
+                  "description": "The total number of rows present in the table."
+                },
                 "stale": {
                   "type": "number",
                   "description": "The number of stale rows that are waiting to be processed"
@@ -2388,7 +3692,12 @@
                   "description": "The number of rows that are waiting to be indexed (for search)"
                 }
               },
-              "required": ["table", "rows", "stale", "indexing"],
+              "required": [
+                "table",
+                "rows",
+                "stale",
+                "indexing"
+              ],
               "title": "getTableResponse",
               "additionalProperties": false
             }
@@ -2402,9 +3711,17 @@
             "schema": {
               "type": "object",
               "properties": {
-                "table": { "$ref": "#/components/schemas/Table" },
-                "created": { "type": "boolean", "description": "Flag indicating if the table was newly created." },
-                "rows": { "type": "number", "description": "The total number of rows present in the table." },
+                "table": {
+                  "$ref": "#/components/schemas/Table"
+                },
+                "created": {
+                  "type": "boolean",
+                  "description": "Flag indicating if the table was newly created."
+                },
+                "rows": {
+                  "type": "number",
+                  "description": "The total number of rows present in the table."
+                },
                 "stale": {
                   "type": "number",
                   "description": "The number of stale rows that are waiting to be processed"
@@ -2414,7 +3731,13 @@
                   "description": "The number of rows that are waiting to be indexed (for search)"
                 }
               },
-              "required": ["table", "created", "rows", "stale", "indexing"],
+              "required": [
+                "table",
+                "created",
+                "rows",
+                "stale",
+                "indexing"
+              ],
               "title": "getOrCreateTableResponse",
               "additionalProperties": false
             }
@@ -2427,8 +3750,14 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "properties": { "table": { "$ref": "#/components/schemas/Table" } },
-              "required": ["table"],
+              "properties": {
+                "table": {
+                  "$ref": "#/components/schemas/Table"
+                }
+              },
+              "required": [
+                "table"
+              ],
               "title": "createTableResponse",
               "additionalProperties": false
             }
@@ -2442,10 +3771,18 @@
             "schema": {
               "type": "object",
               "properties": {
-                "table": { "$ref": "#/components/schemas/Table" },
-                "rows": { "type": "number", "description": "The total number of rows present in the table." }
+                "table": {
+                  "$ref": "#/components/schemas/Table"
+                },
+                "rows": {
+                  "type": "number",
+                  "description": "The total number of rows present in the table."
+                }
               },
-              "required": ["table", "rows"],
+              "required": [
+                "table",
+                "rows"
+              ],
               "title": "duplicateTableResponse",
               "additionalProperties": false
             }
@@ -2462,19 +3799,52 @@
                 "job": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "botId": { "type": "string" },
-                    "tableId": { "type": "string" },
-                    "type": { "type": "string", "enum": ["export", "import"] },
+                    "id": {
+                      "type": "string"
+                    },
+                    "botId": {
+                      "type": "string"
+                    },
+                    "tableId": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "export",
+                        "import"
+                      ]
+                    },
                     "status": {
                       "type": "string",
-                      "enum": ["pending", "in_progress", "finalizing", "completed", "failed"]
+                      "enum": [
+                        "pending",
+                        "in_progress",
+                        "finalizing",
+                        "completed",
+                        "failed"
+                      ]
                     },
-                    "progress": { "default": 0, "type": "number" },
-                    "inputFileId": { "type": "string", "nullable": true },
-                    "outputFileId": { "type": "string", "nullable": true },
-                    "createdAt": { "type": "string", "format": "date-time" },
-                    "updatedAt": { "type": "string", "format": "date-time" }
+                    "progress": {
+                      "default": 0,
+                      "type": "number"
+                    },
+                    "inputFileId": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "outputFileId": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
                   },
                   "required": [
                     "id",
@@ -2490,7 +3860,9 @@
                   "additionalProperties": false
                 }
               },
-              "required": ["job"],
+              "required": [
+                "job"
+              ],
               "title": "exportTableResponse",
               "additionalProperties": false
             }
@@ -2509,19 +3881,52 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "id": { "type": "string" },
-                      "botId": { "type": "string" },
-                      "tableId": { "type": "string" },
-                      "type": { "type": "string", "enum": ["export", "import"] },
+                      "id": {
+                        "type": "string"
+                      },
+                      "botId": {
+                        "type": "string"
+                      },
+                      "tableId": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "export",
+                          "import"
+                        ]
+                      },
                       "status": {
                         "type": "string",
-                        "enum": ["pending", "in_progress", "finalizing", "completed", "failed"]
+                        "enum": [
+                          "pending",
+                          "in_progress",
+                          "finalizing",
+                          "completed",
+                          "failed"
+                        ]
                       },
-                      "progress": { "default": 0, "type": "number" },
-                      "inputFileId": { "type": "string", "nullable": true },
-                      "outputFileId": { "type": "string", "nullable": true },
-                      "createdAt": { "type": "string", "format": "date-time" },
-                      "updatedAt": { "type": "string", "format": "date-time" }
+                      "progress": {
+                        "default": 0,
+                        "type": "number"
+                      },
+                      "inputFileId": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "outputFileId": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      }
                     },
                     "required": [
                       "id",
@@ -2537,7 +3942,9 @@
                   }
                 }
               },
-              "required": ["jobs"],
+              "required": [
+                "jobs"
+              ],
               "title": "getTableJobsResponse",
               "additionalProperties": false
             }
@@ -2554,19 +3961,52 @@
                 "job": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "botId": { "type": "string" },
-                    "tableId": { "type": "string" },
-                    "type": { "type": "string", "enum": ["export", "import"] },
+                    "id": {
+                      "type": "string"
+                    },
+                    "botId": {
+                      "type": "string"
+                    },
+                    "tableId": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "export",
+                        "import"
+                      ]
+                    },
                     "status": {
                       "type": "string",
-                      "enum": ["pending", "in_progress", "finalizing", "completed", "failed"]
+                      "enum": [
+                        "pending",
+                        "in_progress",
+                        "finalizing",
+                        "completed",
+                        "failed"
+                      ]
                     },
-                    "progress": { "default": 0, "type": "number" },
-                    "inputFileId": { "type": "string", "nullable": true },
-                    "outputFileId": { "type": "string", "nullable": true },
-                    "createdAt": { "type": "string", "format": "date-time" },
-                    "updatedAt": { "type": "string", "format": "date-time" }
+                    "progress": {
+                      "default": 0,
+                      "type": "number"
+                    },
+                    "inputFileId": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "outputFileId": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
                   },
                   "required": [
                     "id",
@@ -2582,7 +4022,9 @@
                   "additionalProperties": false
                 }
               },
-              "required": ["job"],
+              "required": [
+                "job"
+              ],
               "title": "importTableResponse",
               "additionalProperties": false
             }
@@ -2596,14 +4038,20 @@
             "schema": {
               "type": "object",
               "properties": {
-                "table": { "$ref": "#/components/schemas/Table" },
+                "table": {
+                  "$ref": "#/components/schemas/Table"
+                },
                 "staleColumns": {
                   "type": "array",
-                  "items": { "type": "string" },
+                  "items": {
+                    "type": "string"
+                  },
                   "description": "List of columns that have become stale following the modification."
                 }
               },
-              "required": ["table"],
+              "required": [
+                "table"
+              ],
               "title": "updateTableResponse",
               "additionalProperties": false
             }
@@ -2616,8 +4064,14 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "properties": { "table": { "$ref": "#/components/schemas/Table" } },
-              "required": ["table"],
+              "properties": {
+                "table": {
+                  "$ref": "#/components/schemas/Table"
+                }
+              },
+              "required": [
+                "table"
+              ],
               "title": "renameTableColumnResponse",
               "additionalProperties": false
             }
@@ -2628,7 +4082,11 @@
         "description": "Confirmation that the table has been deleted.",
         "content": {
           "application/json": {
-            "schema": { "type": "object", "title": "deleteTableResponse", "additionalProperties": false }
+            "schema": {
+              "type": "object",
+              "title": "deleteTableResponse",
+              "additionalProperties": false
+            }
           }
         }
       },
@@ -2638,8 +4096,14 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "properties": { "row": { "$ref": "#/components/schemas/Row" } },
-              "required": ["row"],
+              "properties": {
+                "row": {
+                  "$ref": "#/components/schemas/Row"
+                }
+              },
+              "required": [
+                "row"
+              ],
               "title": "getTableRowResponse",
               "additionalProperties": false
             }
@@ -2653,17 +4117,36 @@
             "schema": {
               "type": "object",
               "properties": {
-                "rows": { "type": "array", "items": { "$ref": "#/components/schemas/Row" } },
-                "hasMore": { "type": "boolean", "description": "Flag indicating if there are more rows to fetch." },
-                "offset": { "type": "integer" },
-                "limit": { "type": "integer" },
+                "rows": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Row"
+                  }
+                },
+                "hasMore": {
+                  "type": "boolean",
+                  "description": "Flag indicating if there are more rows to fetch."
+                },
+                "offset": {
+                  "type": "integer"
+                },
+                "limit": {
+                  "type": "integer"
+                },
                 "warnings": {
                   "type": "array",
-                  "items": { "type": "string" },
+                  "items": {
+                    "type": "string"
+                  },
                   "description": "Alerts for minor issues that don't block the operation but suggest possible improvements."
                 }
               },
-              "required": ["rows", "hasMore", "offset", "limit"],
+              "required": [
+                "rows",
+                "hasMore",
+                "offset",
+                "limit"
+              ],
               "title": "findTableRowsResponse",
               "additionalProperties": false
             }
@@ -2677,19 +4160,30 @@
             "schema": {
               "type": "object",
               "properties": {
-                "rows": { "type": "array", "items": { "$ref": "#/components/schemas/Row" } },
+                "rows": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Row"
+                  }
+                },
                 "warnings": {
                   "type": "array",
-                  "items": { "type": "string" },
+                  "items": {
+                    "type": "string"
+                  },
                   "description": "Alerts for minor issues that don't block the operation but suggest possible improvements."
                 },
                 "errors": {
                   "type": "array",
-                  "items": { "type": "string" },
+                  "items": {
+                    "type": "string"
+                  },
                   "description": "Critical issues in specific elements that prevent their successful processing, allowing partial operation success."
                 }
               },
-              "required": ["rows"],
+              "required": [
+                "rows"
+              ],
               "title": "createTableRowsResponse",
               "additionalProperties": false
             }
@@ -2702,8 +4196,14 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "properties": { "deletedRows": { "type": "number" } },
-              "required": ["deletedRows"],
+              "properties": {
+                "deletedRows": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "deletedRows"
+              ],
               "title": "deleteTableRowsResponse",
               "additionalProperties": false
             }
@@ -2717,19 +4217,30 @@
             "schema": {
               "type": "object",
               "properties": {
-                "rows": { "type": "array", "items": { "$ref": "#/components/schemas/Row" } },
+                "rows": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Row"
+                  }
+                },
                 "warnings": {
                   "type": "array",
-                  "items": { "type": "string" },
+                  "items": {
+                    "type": "string"
+                  },
                   "description": "Alerts for minor issues that don't block the operation but suggest possible improvements."
                 },
                 "errors": {
                   "type": "array",
-                  "items": { "type": "string" },
+                  "items": {
+                    "type": "string"
+                  },
                   "description": "Critical issues in specific elements that prevent their successful processing, allowing partial operation success."
                 }
               },
-              "required": ["rows"],
+              "required": [
+                "rows"
+              ],
               "title": "updateTableRowsResponse",
               "additionalProperties": false
             }
@@ -2743,20 +4254,37 @@
             "schema": {
               "type": "object",
               "properties": {
-                "inserted": { "type": "array", "items": { "$ref": "#/components/schemas/Row" } },
-                "updated": { "type": "array", "items": { "$ref": "#/components/schemas/Row" } },
+                "inserted": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Row"
+                  }
+                },
+                "updated": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Row"
+                  }
+                },
                 "warnings": {
                   "type": "array",
-                  "items": { "type": "string" },
+                  "items": {
+                    "type": "string"
+                  },
                   "description": "Alerts for minor issues that don't block the operation but suggest possible improvements."
                 },
                 "errors": {
                   "type": "array",
-                  "items": { "type": "string" },
+                  "items": {
+                    "type": "string"
+                  },
                   "description": "Critical issues in specific elements that prevent their successful processing, allowing partial operation success."
                 }
               },
-              "required": ["inserted", "updated"],
+              "required": [
+                "inserted",
+                "updated"
+              ],
               "title": "upsertTableRowsResponse",
               "additionalProperties": false
             }
@@ -2790,7 +4318,9 @@
                 },
                 "tags": {
                   "type": "object",
-                  "additionalProperties": { "type": "string" },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "Optional tags to help organize your tables. These should be passed here as an object representing key/value pairs."
                 },
                 "isComputeEnabled": {
@@ -2798,7 +4328,9 @@
                   "description": "Indicates if the table is enabled for computation."
                 }
               },
-              "required": ["schema"],
+              "required": [
+                "schema"
+              ],
               "title": "getOrCreateTableBody",
               "additionalProperties": false
             }
@@ -2835,7 +4367,9 @@
                 },
                 "tags": {
                   "type": "object",
-                  "additionalProperties": { "type": "string" },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "Optional tags to help organize your tables. These should be passed here as an object representing key/value pairs."
                 },
                 "isComputeEnabled": {
@@ -2843,7 +4377,10 @@
                   "description": "Indicates if the table is enabled for computation."
                 }
               },
-              "required": ["name", "schema"],
+              "required": [
+                "name",
+                "schema"
+              ],
               "title": "createTableBody",
               "additionalProperties": false
             }
@@ -2857,8 +4394,13 @@
             "schema": {
               "type": "object",
               "properties": {
-                "tableName": { "type": "string" },
-                "schemaOnly": { "type": "boolean", "description": "Only duplicate the schema, not the content" },
+                "tableName": {
+                  "type": "string"
+                },
+                "schemaOnly": {
+                  "type": "boolean",
+                  "description": "Only duplicate the schema, not the content"
+                },
                 "factor": {
                   "type": "number",
                   "description": "Use a different factor for the table. Leave empty to use the same as the duplicated table."
@@ -2882,7 +4424,9 @@
                   "description": "The file ID to import. It must have been uploaded to the Files API before. Supported formats: CSV, JSON (gzipped or not)"
                 }
               },
-              "required": ["fileId"],
+              "required": [
+                "fileId"
+              ],
               "title": "importTableBody",
               "additionalProperties": false
             }
@@ -2912,7 +4456,9 @@
                 },
                 "tags": {
                   "type": "object",
-                  "additionalProperties": { "type": "string" },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "Optional tags to help organize your tables. These should be passed here as an object representing key/value pairs."
                 },
                 "isComputeEnabled": {
@@ -2933,7 +4479,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "name": { "type": "string", "description": "The existing name of the column." },
+                "name": {
+                  "type": "string",
+                  "description": "The existing name of the column."
+                },
                 "newName": {
                   "description": "The new name to assign to the column.",
                   "type": "string",
@@ -2941,7 +4490,10 @@
                   "maxLength": 30
                 }
               },
-              "required": ["name", "newName"],
+              "required": [
+                "name",
+                "newName"
+              ],
               "title": "renameTableColumnBody",
               "additionalProperties": false
             }
@@ -2991,7 +4543,10 @@
                 "orderDirection": {
                   "default": "asc",
                   "type": "string",
-                  "enum": ["asc", "desc"],
+                  "enum": [
+                    "asc",
+                    "desc"
+                  ],
                   "description": "Specifies the direction of sorting, either ascending or descending."
                 }
               },
@@ -3010,7 +4565,11 @@
               "properties": {
                 "rows": {
                   "type": "array",
-                  "items": { "type": "object", "properties": {}, "additionalProperties": true },
+                  "items": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                  },
                   "minItems": 1,
                   "maxItems": 1000
                 },
@@ -3019,7 +4578,9 @@
                   "description": "Ensure computed columns are fully processed before returning the result. This is applicable only when the number of rows involved is fewer than 1."
                 }
               },
-              "required": ["rows"],
+              "required": [
+                "rows"
+              ],
               "title": "createTableRowsBody",
               "additionalProperties": false
             }
@@ -3033,7 +4594,13 @@
             "schema": {
               "type": "object",
               "properties": {
-                "ids": { "type": "array", "items": { "type": "number" }, "maxItems": 1000 },
+                "ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 1000
+                },
                 "filter": {
                   "type": "object",
                   "additionalProperties": true,
@@ -3061,8 +4628,14 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "properties": { "id": { "type": "number" } },
-                    "required": ["id"],
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "id"
+                    ],
                     "additionalProperties": true
                   },
                   "minItems": 1,
@@ -3074,7 +4647,9 @@
                   "description": "Ensure computed columns are fully processed before returning the result. This is applicable only when the number of rows involved is fewer than 1."
                 }
               },
-              "required": ["rows"],
+              "required": [
+                "rows"
+              ],
               "title": "updateTableRowsBody",
               "additionalProperties": false
             }
@@ -3092,7 +4667,11 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "properties": { "id": { "type": "number" } },
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      }
+                    },
                     "additionalProperties": true
                   },
                   "minItems": 1,
@@ -3110,7 +4689,9 @@
                   "description": "Ensure computed columns are fully processed before returning the result. This is applicable only when the number of rows involved is fewer than 1."
                 }
               },
-              "required": ["rows"],
+              "required": [
+                "rows"
+              ],
               "title": "upsertTableRowsBody",
               "additionalProperties": false
             }
@@ -3119,5 +4700,11 @@
       }
     },
     "parameters": {}
-  }
+  },
+  "security": [
+      {
+        "BearerAuth": [],
+        "BotIdHeader": []
+      }
+    ]
 }


### PR DESCRIPTION
Adds missing headers for the Admin API, Files API, Tables API and Runtime API. This fixes the documentation's API playground, which had been broken since the migration to Mintlify.