### PR TITLE
fix(api/files): client.getFile arg

### DIFF
--- a/api-reference/files-api/how-tos/manage-files.mdx
+++ b/api-reference/files-api/how-tos/manage-files.mdx
@@ -167,7 +167,7 @@ To delete a file you can use the "Delete File" API endpoint.
 <CodeGroup>
 
 ```ts Using the Botpress Client
-await client.deleteFile('YOUR_FILE_ID')
+await client.deleteFile({ id: "YOUR_FILE_ID" })
 ```
 
 ```ts Calling the API directly

--- a/api-reference/files-api/how-tos/manage-files.mdx
+++ b/api-reference/files-api/how-tos/manage-files.mdx
@@ -14,7 +14,7 @@ const client = new Client({
   botId: process.env.BOTPRESS_BOT_ID,
 })
 
-const file = await client.getFile('YOUR_FILE_ID')
+const file = await client.getFile({ id: "YOUR_FILE_ID" });
 ```
 
 ```ts Calling the API directly


### PR DESCRIPTION
Corrects the argument for `client.getFile` since it expects an object, not a string.