### PR TITLE
feat(assistant): add hash to open on load

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -37,6 +37,14 @@ function loadWebchat() {
       },
       clientId: '44246de9-1d1b-462c-8ef3-1ce39e65d89a',
   })
+  url = new URL(window.location.href)
+  if (url.hash === "#ask" ) window.botpress.open()
+
+  window.addEventListener("hashchange", () => {
+    if (window.location.hash === "#ask") {
+      window.botpress.open()
+    }
+  })
 };
 
 function askAi() {


### PR DESCRIPTION
Adds JavaScript so that the docs bot opens proactively when users add the `#ask` hash to a docs URL.

For example: https://botpress.com/docs#ask