### PR TITLE
feat(docs): Replace logo link with botpress homepage

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -620,7 +620,8 @@
   },
   "logo": {
     "light": "/logo/light.svg",
-    "dark": "/logo/dark.svg"
+    "dark": "/logo/dark.svg",
+    "href": "https://botpress.com"
   },
   "navbar": {
     "primary": {


### PR DESCRIPTION
Here's a suggestion to make the Botpress logo in the docs site bring people back to the Botpress site proper.

Currently, it brings people back to the home page on the docs, but there's already a Home button which brings them back to the home page.

@adkah up to you on the desired behaviour.