### PR TITLE
feat(integrations): add hubspot guide

### DIFF
--- a/.vale/styles/config/vocabularies/botpress-vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/botpress-vocab/accept.txt
@@ -42,3 +42,4 @@ PDF(s)?
 Datetime
 (?i)API(s)?
 Calendly
+HubSpot

--- a/docs.json
+++ b/docs.json
@@ -272,7 +272,6 @@
               "/integrations/integration-guides/google-calendar",
               "/integrations/integration-guides/google-sheet",
               "/integrations/integration-guides/hitl",
-              "/integrations/integration-guides/hubspot",
               "/integrations/integration-guides/instagram",
               "/integrations/integration-guides/intercom",
               "/integrations/integration-guides/line",

--- a/docs.json
+++ b/docs.json
@@ -272,6 +272,7 @@
               "/integrations/integration-guides/google-calendar",
               "/integrations/integration-guides/google-sheet",
               "/integrations/integration-guides/hitl",
+              "/integrations/integration-guides/hubspot",
               "/integrations/integration-guides/instagram",
               "/integrations/integration-guides/intercom",
               "/integrations/integration-guides/line",

--- a/integrations/integration-guides/hubspot.mdx
+++ b/integrations/integration-guides/hubspot.mdx
@@ -169,12 +169,12 @@ The official HubSpot integration allows your bot to interact with your HubSpot a
 
         </Step>
       </Steps>
-
-      <Check>
-        Your HubSpot integration is ready—you can use the integration's [Cards](/learn/reference/cards/introduction) and [Triggers](/learn/reference/triggers) to interact with your HubSpot account.
-      </Check>
   </Tab>
 </Tabs>
+
+<Check>
+  Your HubSpot integration is ready—you can use the integration's [Cards](/learn/reference/cards/introduction) and [Triggers](/learn/reference/triggers) to interact with your HubSpot account.
+</Check>
 
 {/* ---
 

--- a/integrations/integration-guides/hubspot.mdx
+++ b/integrations/integration-guides/hubspot.mdx
@@ -1,0 +1,201 @@
+---
+title: HubSpot
+description: Add a bot to HubSpot using the official integration.
+---
+
+The official HubSpot integration allows your bot to interact with your HubSpot account.
+
+## Setup
+
+<Tabs>
+  <Tab title="Automatic configuration">
+    <Info>
+      You will need:
+
+      - A [published bot](/learn/get-started/quick-start)
+      - A [HubSpot account](https://hubspot.com)
+    </Info>
+
+    1. In Botpress Studio, select **Explore Hub** in the upper-right corner.
+    2. Search for the **HubSpot** integration, then select **Install Integration**.
+    3. In the **Configuration** menu, select **Authorize HubSpot**.
+    4. Follow the instructions to connect Botpress to your HubSpot account.
+  </Tab>
+  <Tab title="Manual configuration">
+    For advanced use cases, you can use your own HubSpot app with our integration.
+
+    <Info>
+      You will need:
+
+      - A [published bot](/learn/get-started/quick-start)
+      - A [HubSpot account](https://hubspot.com)
+      </Info>
+
+      {/* ### Step 1: Install the HubSpot integration in Botpress
+
+      1. In Botpress Studio, select **Explore Hub** in the upper-right corner.
+      2. Search for the **HubSpot** integration, then select **Install Integration**.
+      3. In the **Configuration** menu, select the drop-down menu, then select **Idk what the name of this button is**.
+      4. Copy the webhook URL—you'll need it when configuring your HubSpot app.
+      5. Leave the configuration fields empty for now—you'll come back to them after you've setup your HubSpot app.
+
+      ### Step 2: Create a HubSpot app
+
+      Next, you'll need to create a HubSpot app for your bot:
+
+      1. Open a new tab and [log into your HubSpot account](https://app.hubspot.com/login).
+      2. In the upper-right corner, select your organization name, then select **Profile & Preferences**.
+      3. Under **Account Management**, select **Integrations**, then **Legacy Apps**.
+      4. Select **Create** in the upper-right corner. Then, select **Private**.
+
+      #### Add scopes
+
+      Now, add the required scopes for the HubSpot app to work:
+
+      1. In the **Scopes** section, select **+ Add new scope**.
+      2. Add the following scopes:
+          - `oauth`
+          - `tickets`
+          - `crm.objects.contacts.read`
+          - `crm.objects.contacts.write`
+          - `crm.objects.owners.read`
+          - `crm.objects.companies.read`
+          - `crm.objects.companies.write`
+          - `crm.objects.leads.read`
+          - `crm.objects.leads.write`
+          - `crm.objects.deals.read`
+          - `crm.objects.deals.write`
+      3. When you're done, select **Update**.
+
+      #### Subscribe to Webhook events
+
+      Optionally, you can subscribe to Webhook events—these are necessary if you want to use the integration's [Triggers](brokenahlink):
+
+      1. Navigate to the **Webhooks** tab, then paste the webhook URL you copied earlier into the **Target URL** field.
+      2. Set **Event throttling** to `1`, then select **Create subscription**.
+      3. Enable **Use expanded object support**.
+      4. From the **Which object types** drop-down, select:
+          - Company
+          - Contact
+          - Ticket
+          - Lead
+      5. From the **Listen for which events** drop-down, select:
+          - Created
+          - Deleted
+      6. Select **Subscribe**.
+      7. Select **Create app** in the upper-right corner. Then, select **Continue creating**.
+
+      ### Step 3: Configure the integration in Botpress
+
+      Now you can use your app's credentials to fill in the configuration fields from [Step 1](#step-1-install-the-hubspot-integration-in-botpress):
+
+      1. From your HubSpot app's menu, navigate to the **Auth** tab.
+      2. Copy the **Access token** and **Client secret**.
+      3. Paste them into the integration's **Access Token** and **Client Secret** fields.
+      4. Scroll down and select **Save Configuration**. This automatically activates the integration.
+
+      <Check>
+        Your HubSpot integration is ready—you can use the integration's [Cards](brokenahlink2) and [Triggers](brokenahlink3) to interact with your HubSpot account.
+      </Check> */}
+
+
+      <Steps titleSize="h3">
+        <Step title="Install the HubSpot integration in Botpress">
+
+          1. In Botpress Studio, select **Explore Hub** in the upper-right corner.
+          2. Search for the **HubSpot** integration, then select **Install Integration**.
+          3. In the **Configuration** menu, select the drop-down menu, then select **Configure the integration using a HubSpot integration token**.
+          4. Copy the webhook URL—you'll need it when configuring your HubSpot app.
+          5. Leave the configuration fields empty for now—you'll come back to them after you've setup your HubSpot app.
+
+        </Step>
+
+        <Step title="Create a HubSpot app">
+
+          Next, you'll need to create a HubSpot app for your bot:
+
+          1. Open a new tab and [log into your HubSpot account](https://app.hubspot.com/login).
+          2. In the upper-right corner, select your organization name, then select **Profile & Preferences**.
+          3. Under **Account Management**, select **Integrations**, then **Legacy Apps**.
+          4. Select **Create** in the upper-right corner. Then, select **Private**.
+
+        </Step>
+
+        <Step title="Add scopes to your HubSpot app">
+          Now, add the required scopes for the HubSpot app to work:
+
+          1. In the **Scopes** section, select **+ Add new scope**.
+          2. Add the following scopes:
+              - `oauth`
+              - `tickets`
+              - `crm.objects.contacts.read`
+              - `crm.objects.contacts.write`
+              - `crm.objects.owners.read`
+              - `crm.objects.companies.read`
+              - `crm.objects.companies.write`
+              - `crm.objects.leads.read`
+              - `crm.objects.leads.write`
+              - `crm.objects.deals.read`
+              - `crm.objects.deals.write`
+          3. When you're done, select **Update**.
+        </Step>
+
+        <Step title="Subscribe to Webhook events (optional)">
+          Optionally, you can subscribe to Webhook events—these are necessary if you want to use the integration's [Triggers](/learn/reference/triggers):
+
+          1. Navigate to the **Webhooks** tab, then paste the webhook URL you copied earlier into the **Target URL** field.
+          2. Set **Event throttling** to `1`, then select **Create subscription**.
+          3. Enable **Use expanded object support**.
+          4. From the **Which object types** drop-down, select:
+              - Company
+              - Contact
+              - Ticket
+              - Lead
+          5. From the **Listen for which events** drop-down, select:
+              - Created
+              - Deleted
+          6. Select **Subscribe**.
+          7. Select **Create app** in the upper-right corner. Then, select **Continue creating**.
+        </Step>
+
+        <Step title="Configure the integration in Botpress">
+
+          Now you can use your app's credentials to fill in the configuration fields from [Step 1](#step-1-install-the-hubspot-integration-in-botpress):
+
+          1. From your HubSpot app's menu, navigate to the **Auth** tab.
+          2. Copy the **Access token** and **Client secret**.
+          3. Paste them into the integration's **Access Token** and **Client Secret** fields.
+          4. Scroll down and select **Save Configuration**. This automatically activates the integration.
+
+        </Step>
+      </Steps>
+
+      <Check>
+        Your HubSpot integration is ready—you can use the integration's [Cards](/learn/reference/cards/introduction) and [Triggers](/learn/reference/triggers) to interact with your HubSpot account.
+      </Check>
+  </Tab>
+</Tabs>
+
+{/* ---
+
+## Cards
+
+Here's a list of all [Cards](/learn/reference/cards/introduction) available with the HubSpot integration:
+
+### Create Contact
+
+Creates a new contact in HubSpot.
+
+**Input fields**:
+
+<Expandable>
+  <ResponseField
+    name="Show input fields"
+    type="type"
+  >
+
+  </ResponseField>
+</Expandable>
+
+**Output**:
+ */}


### PR DESCRIPTION
Adds a guide to setting up the new HubSpot integration. The guide is unlisted for now, meaning it's only accessible via direct link—this is because we needed to provide a documentation link when submitting our app for HubSpot approval.

Closes DOCS-15