### PR TITLE
feat(integrations): add hub button and version

### DIFF
--- a/home.mdx
+++ b/home.mdx
@@ -9,7 +9,7 @@ mode: 'custom'
     Learn how to use Botpress through guides and examples.
   </p>
   <div className="flex gap-4 justify-center mb-8">
-    <button onClick={() => askAi()} className="ai-banner w-inline-block">
+    <button onClick={() => askAi()} className="button w-inline-block">
       <div className="flex items-center gap-2">
         <img id="ai-bolt" src="/homepage-assets/bolt-white-transparent-fill.svg" alt="bolt icon"/>
         <span>Ask AI</span>

--- a/integrations/integration-guides/asana.mdx
+++ b/integrations/integration-guides/asana.mdx
@@ -2,6 +2,15 @@
 title: Asana
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.asana}/>
+
 Asana Integration allows you to seamlessly connect your Botpress and Asana, a well-established project management platform. This integration equips your bot with the ability to manage projects and tasks right from its interface. After the setup, you will be able to perform actions such as task creation, task updates, task comment addition, and more.
 
 ## Prerequisites

--- a/integrations/integration-guides/chat.mdx
+++ b/integrations/integration-guides/chat.mdx
@@ -2,6 +2,16 @@
 title: Chat
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.chat}/>
+
+
 The official Chat integration offers an **HTTP API to chat with your bot**.
 
 <Card

--- a/integrations/integration-guides/gmail.mdx
+++ b/integrations/integration-guides/gmail.mdx
@@ -1,3 +1,13 @@
+
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.gmail}/>
+
 The Gmail integration allows your bot to chat with users via your Gmail address.
 
 <Danger>
@@ -82,7 +92,7 @@ Due to the sensitive nature of email communication, the Gmail integration requir
         6. Under **Authorized redirect URIs**, enter `https://botpress.com`.
         7. Select **Add URI**, then **Create**.
         8. Copy the **Client ID** and **Client secret** for use in the next steps.
-        
+
         <Note>
         The client ID is the string that ends with `.apps.googleusercontent.com`.
         </Note>
@@ -113,7 +123,7 @@ Due to the sensitive nature of email communication, the Gmail integration requir
         5. Uncheck the **Add default subscription** checkbox. Leave the other options unchanged.
         7. Select **Create** to create the topic.
         8. Copy the **Topic name** for use in the next steps.
-        
+
         <Note>
         The topic name is the string that starts with `projects/`.
         </Note>
@@ -137,7 +147,7 @@ Due to the sensitive nature of email communication, the Gmail integration requir
         ### Step 8. Generate a shared secret
 
         1. Generate an alphanumeric string to use as a shared secret for signing Pub/Sub push events. We recommend using a string with at least 32 characters.
-        
+
         <Tip>
         You can use an [online password generator](https://bitwarden.com/password-generator/) to create a secure string.
         </Tip>
@@ -156,14 +166,14 @@ Due to the sensitive nature of email communication, the Gmail integration requir
 
         <Tip>
         For example, if:
-        
+
         - Your integration's webhook URL is: `https://webhook.botpress.cloud/57fcfb04-51fd-4381-909a-10e6ae53d310`
         - Your shared secret is `Ut5hzrxs7uV87mzCAKL3ztrzesWWBiNa`
-        
+
         You would enter:
-        
+
         `https://webhook.botpress.cloud/57fcfb04-51fd-4381-909a-10e6ae53d310?shared_secret=Ut5hzrxs7uV87mzCAKL3ztrzesWWBiNa`
-        
+
         in the **Endpoint URL** field.
         </Tip>
 

--- a/integrations/integration-guides/google-calendar.mdx
+++ b/integrations/integration-guides/google-calendar.mdx
@@ -2,6 +2,16 @@
 title: Google Calendar
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.googlecalendar}/>
+
+
 
 The Google Calendar Integration for Botpress enables your bot to access and create Google Calendar data in real-time, automating tasks like CRM updates, inventory management, and survey tracking directly within chat.
 

--- a/integrations/integration-guides/google-sheet.mdx
+++ b/integrations/integration-guides/google-sheet.mdx
@@ -2,6 +2,16 @@
 title: Google Sheet
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.gsheets}/>
+
+
 
 The Google Sheets Integration for Botpress enables your bot to access and update Google Sheets data in real-time, automating tasks like CRM updates, inventory management, and survey tracking directly within chat.
 

--- a/integrations/integration-guides/hitl.mdx
+++ b/integrations/integration-guides/hitl.mdx
@@ -5,6 +5,16 @@ description: >-
   conversation.
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.hitl}/>
+
+
 The Human-in-the-Loop (HITL) integration brings human oversight and intervention into AI-driven Workflows. It allows members of your Workspace to:
 
 - Chat directly with users

--- a/integrations/integration-guides/hubspot.mdx
+++ b/integrations/integration-guides/hubspot.mdx
@@ -3,6 +3,16 @@ title: HubSpot
 description: Add a bot to HubSpot using the official integration.
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.hubspot}/>
+
+
 The official HubSpot integration allows your bot to interact with your HubSpot account.
 
 ## Setup

--- a/integrations/integration-guides/instagram.mdx
+++ b/integrations/integration-guides/instagram.mdx
@@ -2,6 +2,16 @@
 description: Add your bot to Instagram using the official integration.
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.instagram}/>
+
+
 The official Instagram integration allows your users to chat with your bot by messaging an Instagram account.
 
 ## Setup

--- a/integrations/integration-guides/intercom.mdx
+++ b/integrations/integration-guides/intercom.mdx
@@ -2,6 +2,16 @@
 title: Intercom
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.intercom}/>
+
+
 
 <img src="./assets/intercom.png" />
 

--- a/integrations/integration-guides/line.mdx
+++ b/integrations/integration-guides/line.mdx
@@ -2,6 +2,16 @@
 title: Line
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.line}/>
+
+
 
 <img src="./assets/line.png" />
 

--- a/integrations/integration-guides/messenger.mdx
+++ b/integrations/integration-guides/messenger.mdx
@@ -2,7 +2,17 @@
 title: Messenger
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+<OpenInHub integration={integrationVersions.messenger}/>
+
+
 import { YouTube } from '/snippets/youtube.mdx'
+
+{/* vale on */}
 
 <img src="./assets/messenger.png" />
 

--- a/integrations/integration-guides/microsoft-teams.mdx
+++ b/integrations/integration-guides/microsoft-teams.mdx
@@ -2,6 +2,16 @@
 title: Microsoft Teams
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.teams}/>
+
+
 
 <img src="./assets/microsoft-teams.png" />
 

--- a/integrations/integration-guides/notion.mdx
+++ b/integrations/integration-guides/notion.mdx
@@ -2,6 +2,16 @@
 title: Notion
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.notion}/>
+
+
 
 <img src="./assets/notion.png" />
 

--- a/integrations/integration-guides/slack/setup.mdx
+++ b/integrations/integration-guides/slack/setup.mdx
@@ -4,8 +4,18 @@ sidebarTitle: Setup
 description: Add a bot to Slack using the official integration.
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+<OpenInHub integration={integrationVersions.slack}/>
+
+
 import JsonManifest from "/snippets/integrations/slack-manifest-json.mdx"
 import YamlManifest from "/snippets/integrations/slack-manifest-yaml.mdx"
+
+{/* vale on */}
 
 The official Slack integration allows members of your Slack workspace to chat with your bot via a Slack app.
 

--- a/integrations/integration-guides/sunshine-conversations/introduction.mdx
+++ b/integrations/integration-guides/sunshine-conversations/introduction.mdx
@@ -3,6 +3,16 @@ title: Sunshine Conversations
 sidebarTitle: Introduction
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.sunco}/>
+
+
 
 <img src="./assets/sunshine-conversations.png" />
 

--- a/integrations/integration-guides/sunshine-conversations/zendesk-messaging.mdx
+++ b/integrations/integration-guides/sunshine-conversations/zendesk-messaging.mdx
@@ -2,6 +2,16 @@
 title: Zendesk Messaging
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.sunco}/>
+
+
 <img src="./assets/sunshine-conversation-zendesk.png" />
 
 You can also use the Sunshine Conversations integration to connect Botpress to Zendesk Messaging.

--- a/integrations/integration-guides/telegram.mdx
+++ b/integrations/integration-guides/telegram.mdx
@@ -2,7 +2,17 @@
 title: Telegram
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+<OpenInHub integration={integrationVersions.telegram}/>
+
+
 import { YouTube } from '/snippets/youtube.mdx'
+
+{/* vale on */}
 
 <img src="./assets/telegram.png" />
 

--- a/integrations/integration-guides/trello.mdx
+++ b/integrations/integration-guides/trello.mdx
@@ -2,6 +2,16 @@
 title: Trello
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.trello}/>
+
+
 
 <img src="./assets/trello.png" />
 

--- a/integrations/integration-guides/twilio.mdx
+++ b/integrations/integration-guides/twilio.mdx
@@ -2,6 +2,16 @@
 title: Twilio
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.twilio}/>
+
+
 
 <img src="./assets/twilio.png" />
 

--- a/integrations/integration-guides/viber.mdx
+++ b/integrations/integration-guides/viber.mdx
@@ -2,6 +2,16 @@
 title: Viber
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.viber}/>
+
+
 
 <img src="./assets/viber.png" />
 

--- a/integrations/integration-guides/vonage.mdx
+++ b/integrations/integration-guides/vonage.mdx
@@ -2,6 +2,16 @@
 title: Vonage
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.vonage}/>
+
+
 
 <img src="./assets/vonage.png" />
 

--- a/integrations/integration-guides/webhook.mdx
+++ b/integrations/integration-guides/webhook.mdx
@@ -2,6 +2,14 @@
 title: Webhook
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+<OpenInHub integration={integrationVersions.webhook}/>
+
+
 import webhookPayloadSize from "/snippets/api-payload-limits.mdx"
 
 <img src="./assets/webhook.png" />
@@ -33,6 +41,8 @@ This code example uses the Axios library to make a POST request to the Webhook U
 
 ```js
 import axios from 'axios'
+
+{/* vale on */}
 
 const webhookUrl = 'https://your-webhook.url'
 const data = {

--- a/integrations/integration-guides/whatsapp/introduction.mdx
+++ b/integrations/integration-guides/whatsapp/introduction.mdx
@@ -4,6 +4,16 @@ description: Add a bot to WhatsApp using the official integration.
 sidebarTitle: Setup
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.whatsapp}/>
+
+
 The official WhatsApp integration allows your users to chat with your bot by messaging a WhatsApp number.
 
 ## Setup

--- a/integrations/integration-guides/zapier.mdx
+++ b/integrations/integration-guides/zapier.mdx
@@ -2,6 +2,16 @@
 title: Zapier
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.zapier}/>
+
+
 
 <Info>
 

--- a/integrations/integration-guides/zendesk.mdx
+++ b/integrations/integration-guides/zendesk.mdx
@@ -3,6 +3,16 @@ title: Zendesk
 description: Integrate your bot with Zendesk using the official integration.
 ---
 
+{/* vale off */}
+
+import integrationVersions from '/snippets/integrations/versions.mdx'
+import { OpenInHub } from '/snippets/integrations/open-in-hub.jsx'
+
+{/* vale on */}
+
+<OpenInHub integration={integrationVersions.zendesk}/>
+
+
 The official Zendesk integration allows you to create and manage support tickets directly from your bot. You can also assign a Zendesk agent to communicate directly with the user, all within the same conversation initially handled by the bot.
 
 <Tip>

--- a/snippets/integrations/open-in-hub.jsx
+++ b/snippets/integrations/open-in-hub.jsx
@@ -1,0 +1,28 @@
+export const OpenInHub = ({ integration }) => {
+    const basePath = 'https://studio.botpress.cloud/home?exploreHub=1&hubItemId='
+    const url = `${basePath}${integration.id}`
+    const version = integration.version
+
+    return (
+        <>
+            <a
+                className="button"
+                href={url}
+            >
+                <span>
+                Open in Hub
+                </span>
+            </a>
+            <i style={{
+                margin: "0",
+                fontStyle: "normal",
+                color: "#666",
+                fontSize: "0.85rem",
+                padding: '.5rem'
+                }}
+            >
+                v{integration.version}
+            </i>
+        </>
+    )
+}

--- a/styles.css
+++ b/styles.css
@@ -44,7 +44,7 @@
   background-size: cover;
 }
 
-.ai-banner {
+.button {
     background-color: #0588f0;
     color: white;
     text-align: center;
@@ -59,7 +59,7 @@
     position: relative
 }
 
-.ai-banner:hover {
+.button:hover {
   opacity: 0.9;
 }
 


### PR DESCRIPTION
Updates every integration doc with an Open in Hub button and the current integration version. Both the link and version automatically update on a weekly basis using the workflow I set up yesterday.

This is the first step in a larger effort to make (and keep) our integration docs tightly linked with what users see in the Studio/Hub.