### PR TITLE
feat(integrations): make hubspot doc public

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -273,6 +273,7 @@
               "/integrations/integration-guides/google-calendar",
               "/integrations/integration-guides/google-sheet",
               "/integrations/integration-guides/hitl",
+              "/integrations/integration-guides/hubspot",
               "/integrations/integration-guides/instagram",
               "/integrations/integration-guides/intercom",
               "/integrations/integration-guides/line",


### PR DESCRIPTION
Since the HubSpot integration is now fully usable with OAuth and manual config, I'm listing it in the integrations navigation.