### PR TITLE
chore: add a tip to Zai

### DIFF
--- a/for-developers/packages/zai/overview.mdx
+++ b/for-developers/packages/zai/overview.mdx
@@ -17,6 +17,12 @@ Zai is built on [Zod schemas](https://zod.dev/) and the Botpress API. We recomme
 
 </Note>
 
+<Tip>
+
+  Zai is imported by default in the [Execute Code cards](https://botpress.com/docs/learn/guides/advanced/use-code#execute-code-cards), [Actions](/learn/guides/advanced/use-code#actions), and [Hooks](learn/guides/advanced/use-code#hooks)
+
+</Tip>
+
 ## Installation
 
 To install Zai, run the following command in your terminal:


### PR DESCRIPTION
Add a tip mentioning that Zai is imported by default in the studio