### PR TITLE
feat(webchat): add guide to updating config 

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -45,11 +45,6 @@ function loadWebchat() {
       window.botpress.open()
     }
   })
-
-  window.botpress.on('webchat:ready', () => {
-    console.log('Webchat has been opened and is ready to receive messages.');
-    window.botpress.sendMessage("hi");
-  });
 };
 
 function askAi() {

--- a/docs.json
+++ b/docs.json
@@ -354,6 +354,7 @@
                   "/webchat/interact/send-custom-events/to-webchat"
                 ]
               },
+              "/webchat/interact/update-config",
               "/webchat/interact/error-handling"
             ]
           },

--- a/webchat/interact/update-config.mdx
+++ b/webchat/interact/update-config.mdx
@@ -1,0 +1,48 @@
+---
+title: Update Webchat configuration
+---
+
+You can update your [Webchat's configuration](/webchat/get-started/configure-your-webchat) dynamically using JavaScript. This is useful if you want to update Webchat's style or settings after it's already loaded on your website.
+
+<Info>
+    You will need:
+
+    - A website with an [embedded bot](/webchat/get-started/quick-start)
+    - Familiarity with JavaScript
+</Info>
+
+## Update configuration
+
+To update Webchat's configuration, you can call the `window.botpress.config` method after Webchat has been initialized:
+
+```js
+window.botpress.config({ configuration: <configuration>, user: <user>});
+```
+
+## Switch to dark theme
+
+Here's an example that updates Webchat's theme to dark mode as soon as Webchat loads:
+
+```js
+const webchatConfig = {
+    "themeMode": "dark",
+};
+
+async function getBotpressUser() {
+  return await window.botpress.getUser();
+}
+
+window.botpress.on('webchat:initialized', () => {
+    window.botpress.config({ configuration: webchatConfig, user: getBotpressUser() });
+});
+```
+
+The above snippet:
+
+1. Waits until [Webchat is initialized](/webchat/interact/listen-to-events#webchat-is-initalized)
+2. [Gets the current Botpress user](/webchat/interact/send-user-data#on-your-website) using the `getUser` method
+3. Updates the `themeMode` configuration to `dark` for the current user`
+
+<Tip>
+  You don't need to provide the entire configuration object every time—just the values that you want to udpate.
+</Tip>

--- a/webchat/interact/update-config.mdx
+++ b/webchat/interact/update-config.mdx
@@ -44,5 +44,5 @@ The above snippet:
 3. Updates the `themeMode` configuration to `dark` for the current user`
 
 <Tip>
-  You don't need to provide the entire configuration object every time—just the values that you want to udpate.
+  You don't need to provide the entire configuration object every time—just the values that you want to update.
 </Tip>


### PR DESCRIPTION
Adds a guide to updating Webchat's config dynamically.

I was going to include a full reference for the method's input schema in this guide, but I think it would be cleaner to have a reference for all Webchat methods in the same place. Gonna work on that tomorrow.