### PR TITLE
feat: add v12 legacy doc

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -138,7 +138,8 @@
                   },
                   "/learn/guides/advanced/kitchen-sink-advanced-starter-template",
                   "/learn/guides/advanced/tips-to-optimize-ai-cost",
-                  "/learn/guides/advanced/retention-period"
+                  "/learn/guides/advanced/retention-period",
+                  "/learn/guides/advanced/v12"
                 ]
               }
             ]

--- a/learn/guides/advanced/v12.mdx
+++ b/learn/guides/advanced/v12.mdx
@@ -1,0 +1,38 @@
+---
+title: Botpress v12 (and self-hosted versions)
+sidebarTitle: Botpress v12
+---
+
+<Warning>
+  Botpress v12 **has been officially sunset** and is no longer available for purchase, download, or new deployments. This includes all other self-hosted or locally installed versions of Botpress (including those available for Microsoft Windows and other platforms),
+</Warning>
+
+## Existing customers
+
+Current customers with active Botpress v12 subscriptions remain fully supported. If you are an existing customer and have questions about your subscription or deployment, please reach out directly to your dedicated account manager for assistance.
+
+## Moving forward with Botpress Cloud
+
+All new users should use [Botpress Cloud](https://app.botpress.cloud), the fully managed web application, which represents the future of the Botpress platform. Botpress Cloud provides continuous improvements, security, and scalability without the need for local installation or maintenance.
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion
+    title="Can I still download Botpress v12 or a self-hosted version?"
+  >
+    No. Botpress v12 and all self-hosted versions are no longer available for download, purchase, or new deployments.
+  </Accordion>
+  <Accordion
+    title="I am an existing Botpress v12 customer. What does this mean for me?"
+  >
+    You remain fully supported. Please contact your dedicated account manager for any questions regarding your subscription or deployment.
+  </Accordion>
+  <Accordion
+    title="What should I use now if I want to build with Botpress?"
+  >
+
+    All new development should be done in [Botpress Cloud](https://app.botpress.cloud).
+
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
Adds a doc explaining that v12 is dead and that new customers should use Cloud.