### PR TITLE
chore: add contextual menu

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -35,7 +35,19 @@
   },
   "interaction": {
       "drilldown": false
-    },
+  },
+  "contextual": {
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity",
+      "mcp",
+      "cursor",
+      "vscode"
+    ]
+  },
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
Re-adds Mintlify's contextual menu for the docs, with helpful options for using the docs with LLMs or an MCP server.