### PR TITLE
fix(whatsapp): clarify message template parameters

### DIFF
--- a/integrations/integration-guides/whatsapp/introduction.mdx
+++ b/integrations/integration-guides/whatsapp/introduction.mdx
@@ -140,6 +140,12 @@ You will need:
 
 ## Cards
 
+<Warning>
+  Some of the integration's Cards use [WhatsApp message templates](https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates/) to send messages to users.
+
+  In WhatsApp, these templates support both [named and positional parameters](https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates/#parameter-formats). However, the integration currently only supports positional parameters. This means you'll get an error if you try to provide named parameters in a Card's `conversation.templateVariablesJson` field.
+</Warning>
+
 <Cards />
 
 ---

--- a/snippets/integrations/versions.mdx
+++ b/snippets/integrations/versions.mdx
@@ -697,7 +697,7 @@ export const integrationVersions = {
   },
   "whatsapp": {
     "version": "4.5.6",
-    "id": "intver_01K7MKM2DH6M361YTZY4DS102H"
+    "id": "intver_01K89A0JEXF95AKNYH1XX6T1ZJ"
   },
   "workday": {
     "version": "2.0.0",

--- a/snippets/integrations/versions.mdx
+++ b/snippets/integrations/versions.mdx
@@ -696,7 +696,7 @@ export const integrationVersions = {
     "id": "intver_01JV7Z1SWQSSDEHK3B1W9YBYBH"
   },
   "whatsapp": {
-    "version": "4.5.5",
+    "version": "4.5.6",
     "id": "intver_01K7MKM2DH6M361YTZY4DS102H"
   },
   "workday": {


### PR DESCRIPTION
Adds a clarification to the WhatsApp doc stating that only positional parameters are currently supported.