### PR TITLE
fix(integrations/bamboohr): missing space

### DIFF
--- a/integrations/integration-guides/bamboohr.mdx
+++ b/integrations/integration-guides/bamboohr.mdx
@@ -30,7 +30,7 @@ The official BambooHR integration allows your bot to interact with your company'
   <Step title="Install the integration in Botpress">
     First, install the integration to your bot:
 
-    1. In Botpress Studio, select **<Icon icon="boxes" />Explore Hub** in the upper-right corner.
+    1. In Botpress Studio, select **<Icon icon="boxes" /> Explore Hub** in the upper-right corner.
     2. Search for the **BambooHR** integration, then select **Install Integration**.
     3. In the drop-down menu, select **Configure manually with your BambooHR API Key**.
     4. Fill the **BambooHR Subdomain** field with your company's subdomain (`https://mycompany.bamboohr.com`)


### PR DESCRIPTION
Adds a missing space between the hub button icon and text. Yup 1 character PR