### PR TITLE
fix(homepage): card content font size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -138,3 +138,7 @@
 img {
   background-color: inherit !important;
 }
+
+[data-component-part="card-content"] {
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
Overrides Mintlify's new font size for Card content, which was making our homepage look wack.