### PR TITLE
fix(bot): layout shift and visual improvements

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -56,6 +56,9 @@ function openChatPanel() {
         toggleButton.classList.add('bot-toggle-expanded');
       }
       localStorage.setItem('bot-panel-open', 'true');
+      if (window.focusComposerInput) {
+        window.focusComposerInput();
+      }
     }
   } else {
     // Panel not created yet, wait a bit and try again

--- a/chatbot-panel.js
+++ b/chatbot-panel.js
@@ -74,7 +74,10 @@
     // Restore panel width from localStorage
     const savedWidth = localStorage.getItem('bot-panel-width');
     if (savedWidth) {
-      panel.style.width = savedWidth;
+      const maxWidth = window.innerWidth * 0.38; // 38vw
+      const savedWidthPx = parseInt(savedWidth, 10);
+      const clampedWidth = Math.min(savedWidthPx, maxWidth);
+      panel.style.width = clampedWidth + 'px';
     }
 
     // Helper function to check if mobile
@@ -150,7 +153,8 @@
       if (!isResizing) return;
       
       const diff = startX - e.clientX; // Inverted because we're resizing from the right
-      const newWidth = Math.max(368, Math.min(600, startWidth + diff));
+      const maxWidth = window.innerWidth * 0.35;
+      const newWidth = Math.max(368, Math.min(maxWidth, startWidth + diff));
       panel.style.width = newWidth + 'px';
       localStorage.setItem('bot-panel-width', newWidth + 'px');
       e.preventDefault();
@@ -283,6 +287,13 @@
       clearTimeout(resizeTimeout);
       resizeTimeout = setTimeout(() => {
         updateOverlay();
+        // Clamp panel width to 38vw max on window resize
+        const currentWidth = parseInt(window.getComputedStyle(panel).width, 10);
+        const maxWidth = window.innerWidth * 0.38; // 38vw
+        if (currentWidth > maxWidth) {
+          panel.style.width = maxWidth + 'px';
+          localStorage.setItem('bot-panel-width', maxWidth + 'px');
+        }
       }, 100);
     });
     

--- a/index.mdx
+++ b/index.mdx
@@ -5,9 +5,9 @@ mode: 'frame'
 
 <div className="high-contrast flex flex-col items-center justify-center w-full" >
   <div className="absolute top-0 left-0 right-0">
-    <img src="https://i.ibb.co/d4TT3kvW/background-dark.webp" className="block dark:hidden pointer-events-none" style={{opacity: "0.7"}} alt="Banner"  data-path="images/hero/background-light.png" data-optimize="true" data-opv="3"  />
+    <img src="https://i.ibb.co/d4TT3kvW/background-dark.webp" className="block dark:hidden pointer-events-none opacity-60" alt="Banner"  data-path="images/hero/background-light.png" data-optimize="true" data-opv="3"  />
 
-    <img src="https://i.ibb.co/d4TT3kvW/background-dark.webp" className="hidden dark:block pointer-events-none" style={{opacity: "0.7"}} alt="Banner" data-path="images/hero/background-dark.png" data-optimize="true" data-opv="3" />
+    <img src="https://i.ibb.co/d4TT3kvW/background-dark.webp" className="hidden dark:block pointer-events-none opacity-60" alt="Banner" data-path="images/hero/background-dark.png" data-optimize="true" data-opv="3" />
   </div>
   <div className="relative z-10 px-4 pt-16 lg:py-48 lg:pb-12 max-w-3xl mx-auto">
   <h1 className="block text-4xl font-medium text-center text-gray-900 dark:text-zinc-50 tracking-tight">
@@ -38,7 +38,7 @@ mode: 'frame'
 
 <div className="flex flex-wrap gap-8 max-w-[56rem] mx-auto px-5 flex-col md:flex-row">
   <div className="home-columns">
-    <h2 class="flex whitespace-pre-wrap group font-semibold prose high-contrast" style={{ fontSize: '24px', marginBottom: '0.5em' }}>
+    <h2 class="flex whitespace-pre-wrap group font-semibold prose high-contrast text-2xl mb-4">
       Build
     </h2>
 
@@ -58,7 +58,7 @@ mode: 'frame'
   </div>
 
   <div className="home-columns">
-    <h2 class="flex whitespace-pre-wrap group font-semibold prose high-contrast" style={{ fontSize: '24px', marginBottom: '0.5em' }}>
+    <h2 class="flex whitespace-pre-wrap group font-semibold prose high-contrast text-2xl mb-4">
       Deploy
     </h2>
 
@@ -78,7 +78,7 @@ mode: 'frame'
   </div>
 
   <div className="home-columns">
-    <h2 class="flex whitespace-pre-wrap group font-semibold prose high-contrast" style={{ fontSize: '24px', marginBottom: '0.5em' }}>
+    <h2 class="flex whitespace-pre-wrap group font-semibold prose high-contrast text-2xl mb-4">
       For developers
     </h2>
 
@@ -94,23 +94,13 @@ mode: 'frame'
   </div>
 </div>
 
-<div
-  style={{
-  maxWidth: '56rem',
-  marginLeft: 'auto',
-  marginRight: 'auto',
-  paddingLeft: '1.25rem',
-  paddingRight: '1.25rem',
-  marginTop: '2em',
-  marginBottom: '2em',
-}}
->
-  <h2 class="flex whitespace-pre-wrap group font-semibold prose high-contrast" style={{ fontSize: '24px' }}>
+<div className="max-w-[56rem] mx-auto px-5 mt-8 mb-8">
+  <h2 class="flex whitespace-pre-wrap group font-semibold prose high-contrast text-2xl">
     Browse by concept
   </h2>
 
   <div>
-    <div class="inline-flex items-center gap-1.5 text-sm text-gray-500  dark:text-gray-400" style={{ marginTop: '1.5em' }}>
+    <div class="inline-flex items-center gap-1.5 text-sm text-gray-500  dark:text-gray-400 mt-6">
       Conversational logic
     </div>
 
@@ -140,7 +130,7 @@ mode: 'frame'
       </Card>
     </CardGroup>
 
-    <div class="inline-flex items-center gap-1.5 text-sm text-gray-500  dark:text-gray-400" style={{ marginTop: '1.5em' }}>
+    <div class="inline-flex items-center gap-1.5 text-sm text-gray-500  dark:text-gray-400 mt-6">
       Data manipulation
     </div>
 
@@ -158,7 +148,7 @@ mode: 'frame'
       </Card>
     </CardGroup>
 
-    <div class="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400" style={{ marginTop: '1.5em' }}>
+    <div class="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mt-6">
       Custom code
     </div>
 
@@ -172,7 +162,7 @@ mode: 'frame'
       </Card>
     </CardGroup>
 
-    <div class="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400" style={{ marginTop: '1.5em' }}>
+    <div class="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mt-6">
       Maintenance
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -134,10 +134,10 @@ img {
 
 #bot-toggle {
   position: fixed;
-  top: 3.50rem;
+  top: 3.55rem;
   right: 0;
   width: 40px;
-  height: calc(100vh - 4.5rem);
+  height: calc(100vh - 4.64rem);
   background-color: light-dark(#f7f7f8, #09090b);
   border-left: 1px solid light-dark(rgb(226,222,230), rgb(255 255 255/.07));
   border-right: none;
@@ -182,12 +182,13 @@ img {
   top: 50%;
   transform: translate(-50%, -50%);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  opacity: 0;
+  opacity: 1;
   transition: opacity 0.2s ease-in-out;
 }
 
 .bot-resize-handle:hover {
   cursor: col-resize;
+  pointer-events: auto;
 }
 
 .bot-panel-collapsed #bot-toggle-close {
@@ -196,7 +197,6 @@ img {
 }
 
 .bot-panel-expanded .bot-resize-handle:hover #bot-toggle-close {
-  opacity: 1;
   pointer-events: auto;
 }
 
@@ -215,14 +215,14 @@ img {
   right: 0;
   width: 400px;
   height: calc(100vh - 4.64rem);
-  background-color: transparent;
+  background-color: light-dark(#f7f7f8, #09090b);
   z-index: 9999;
   display: flex;
   flex-direction: row;
   transform: translateX(100%);
   resize: horizontal;
   overflow: visible;
-  /* transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1); */
+  transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .bot-panel-expanded {
@@ -235,10 +235,10 @@ img {
 
 .bot-resize-handle {
   position: absolute;
-  left: -16px;
+  left: -20px;
   top: 0;
   bottom: 0;
-  width: 32px;
+  width: 40px;
   height: 100%;
   cursor: col-resize;
   background-color: transparent;
@@ -335,7 +335,7 @@ img {
     padding: 0;
     margin: 0;
     transform: translateY(100%);
-    transition: transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
+    transition: transform 0.15s cubic-bezier(0.32, 0.72, 0, 1);
     border-top: 1px solid light-dark(rgb(226,222,230), rgb(255 255 255/.07));
   }
 

--- a/styles.css
+++ b/styles.css
@@ -214,8 +214,6 @@ img {
   top: 3.55rem;
   right: 0;
   width: 400px;
-  min-width: 368px;
-  max-width: 624px;
   height: calc(100vh - 4.64rem);
   background-color: transparent;
   z-index: 9999;


### PR DESCRIPTION
Fixes layout shift with banner and font sizes on landing page, plus improves the new docs bot:

- Adjust max width for bigger screen sizes

- Auto-focus input when toggling

- Always show close toggle

- Clicking anywhere on panel now closes the bot

- Added open/close animation