### PR TITLE
fix: add vale check dependency

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -26,6 +26,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 8.6.2
+      - run: pnpm install -g mdx2vast
       - uses: errata-ai/vale-action@v2.1.1
         with:
           filter_mode: added


### PR DESCRIPTION
Adds the `mdx2vast` dependency to the Vale check, which is required for native MDX support.