### PR TITLE
fix: badges for plus/team plans

### DIFF
--- a/get-started/configure-your-workspace.mdx
+++ b/get-started/configure-your-workspace.mdx
@@ -52,7 +52,7 @@ You can create a new agent at any time by selecting **+ Create Bot** in the uppe
 
 To rename an existing agent, select <Icon icon="ellipsis-vertical"/> then **<Icon icon="square-pen"/> Rename**.
 
-### Enable Always Alive {<Badge color="blue">Plus</Badge>}
+### Enable Always Alive {<Tooltip tip="This feature requires a Botpress Plus plan or higher."><Badge stroke color="blue">Plus</Badge></Tooltip>}
 
 You can enable [Always Alive](#always-alive) on any agent to keep it running continuously, even when no conversation is active. This allows for quicker response times when users first begin a conversation.
 
@@ -229,7 +229,7 @@ Now when your agent hits that specific quota, it'll adjust your plan automatical
   </Accordion>
 </AccordionGroup>
 
-## Manage roles {<Badge color="green">Team</Badge>}
+## Manage roles {<Tooltip tip="This feature requires a Botpress Team plan or higher."><Badge stroke color="green">Team</Badge></Tooltip>}
 
 You can view and update roles for members of your workspace in **<Icon icon="settings"/> Settings** > **Members**.
 

--- a/get-started/manage-your-agent/control-access.mdx
+++ b/get-started/manage-your-agent/control-access.mdx
@@ -7,7 +7,7 @@ tag: Team
 If you're an owner or administrator in your workspace, you can restrict who in your Workspace has access to your agent.
 
 <Info>
-  Access control requires a [Plus plan](https://botpress.com/pricing) or higher.
+  Access control requires a [Team plan](https://botpress.com/pricing) or higher.
 </Info>
 
 <Steps>


### PR DESCRIPTION
Fixes tooltips and badges for Plus/Team plans features in the Getting Started section.