### PR TITLE
Updates FAQ about billing threshold

### DIFF
--- a/get-started/configure-your-workspace.mdx
+++ b/get-started/configure-your-workspace.mdx
@@ -216,7 +216,7 @@ Now when your agent hits that specific quota, it'll adjust your plan automatical
     You can access invoices by selecting **Invoice History** in the **<Icon icon="credit-card"/> Billing** menu.
   </Accordion>
   <Accordion title="Where can I add my Tax ID?">
-     You can access invoices by selecting **Billing Information** in the **<Icon icon="credit-card"/> Billing** menu.
+     You can find, edit, or update your Tax ID by selecting **Billing Information** in the **<Icon icon="credit-card"/> Billing** menu.
   </Accordion>
   <Accordion title="Where can I change which email receives receipts and invoices?">
     You can adjust billing email preferences by selecting **Billing Information** in the **<Icon icon="credit-card"/> Billing** menu.
@@ -226,6 +226,9 @@ Now when your agent hits that specific quota, it'll adjust your plan automatical
   </Accordion>
   <Accordion title="Can I make purchases on Botpress even though my payment has failed?">
     No, you can't upgrade a plan or subscription if your payment fails.
+  </Accordion>
+  <Accordion title="When does Botpress send emails about an add-on quota that is nearing its limit?">
+    Botpress sends email notifications to the owner of a Workspace when a quota has reached 75% (or more) of its usage threshold.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
This PR updates an inaccurate statement in the billing FAQ about Tax IDs.

It also adds an FAQ clarifying at what point we send emails notifying users about billing thresholds.