### PR TITLE
fix: add title frontmatter

### DIFF
--- a/adk/concepts/conversations.mdx
+++ b/adk/concepts/conversations.mdx
@@ -1,3 +1,7 @@
+---
+title: Conversations
+---
+
 Conversations are the primary way your agent handles user messages. Each conversation handler defines how your agent responds to messages from specific channels.
 
 ## Creating a conversation

--- a/adk/concepts/workflows/steps.mdx
+++ b/adk/concepts/workflows/steps.mdx
@@ -1,3 +1,8 @@
+---
+title: Steps
+---
+
+
 This page contains a full reference for the [`step` function](/adk/concepts/workflows/overview#steps).
 
 ```typescript

--- a/adk/introduction.mdx
+++ b/adk/introduction.mdx
@@ -1,3 +1,7 @@
+---
+title: Introduction to the ADK
+---
+
 <Panel>
   <ResponseExample>
     ```ts Basic agent

--- a/adk/project-structure.mdx
+++ b/adk/project-structure.mdx
@@ -1,3 +1,7 @@
+---
+title: Project structure
+---
+
 ADK projects follow a consistent structure that organizes your agent's code, configuration, and dependencies.
 
 ## Directory structure

--- a/adk/quickstart.mdx
+++ b/adk/quickstart.mdx
@@ -1,3 +1,7 @@
+---
+title: Quickstart
+---
+
 This guide walks you through installing the ADK and creating your first agent project.
 
 <Info>

--- a/api-reference/admin-api/concepts.mdx
+++ b/api-reference/admin-api/concepts.mdx
@@ -1,3 +1,7 @@
+---
+title: Concepts
+---
+
 The **Admin API** is used to manage the surrounding infrastructure of the bots. It handles accounts, workspaces, users, quotas, billing, and other administrative functions.
 
 ## Account

--- a/api-reference/admin-api/getting-started.mdx
+++ b/api-reference/admin-api/getting-started.mdx
@@ -1,3 +1,7 @@
+---
+title: Getting started
+---
+
 import adminApiPayloadSize from '/snippets/api-payload-limits.mdx'
 
 The Admin API allows administrators to manage users, settings, and logs within the platform. This guide will help you quickly get up and running with the API.

--- a/api-reference/authentication.mdx
+++ b/api-reference/authentication.mdx
@@ -1,3 +1,7 @@
+---
+title: Authentication
+---
+
 You can authenticate to Botpress's API (`api.botpress.cloud`) as a user, a bot, or an integration. To do so, you'll need to use a token.
 
 <Tip>If you are looking to use the Webchat API or the Chat API to talk to your bot, please refer to the [Chat API documentation](/api-reference/chat-api/introduction) and [Webchat documentation](/webchat/get-started/introduction).</Tip>

--- a/api-reference/errors.mdx
+++ b/api-reference/errors.mdx
@@ -1,3 +1,7 @@
+---
+title: Errors
+---
+
 ## Error Response Types
 
 When an error occurs while calling an API endpoint, the response will return the appropriate HTTP status code as indicated below. The following table outlines possible error type and its corresponding description and status.

--- a/api-reference/files-api/getting-started.mdx
+++ b/api-reference/files-api/getting-started.mdx
@@ -1,3 +1,7 @@
+---
+title: Getting started
+---
+
 import filesApiPayloadSize from "/snippets/api-payload-limits.mdx"
 
 The Files API allows you to upload, download, and manage files and searchable documents for your bots and integrations in Botpress Cloud.

--- a/api-reference/files-api/how-tos/index-and-search-files.mdx
+++ b/api-reference/files-api/how-tos/index-and-search-files.mdx
@@ -1,3 +1,7 @@
+---
+title: Index and search files
+---
+
 ## Creating an indexed file
 
 If you need to index a file for semantic search just pass the `index: true` parameter when creating the file.

--- a/api-reference/files-api/how-tos/manage-files.mdx
+++ b/api-reference/files-api/how-tos/manage-files.mdx
@@ -1,3 +1,7 @@
+---
+title: Manage files
+---
+
 ## Getting the file's metadata
 
 To get the details of a file you can use the [Get File](/api-reference/files-api/how-tos/manage-files#getting-the-file’s-metadata) API endpoint.

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,3 +1,7 @@
+---
+title: Introduction
+---
+
 At Botpress, we love APIs. Every API we develop—whether public or private—is carefully designed with a strong focus on coherence and consistency. API design is at the core of our development process.
 
 Botpress is also a very big and complex system, and there isn't a single API that does everything. Instead, we provide multiple APIs, each tailored to specific functionalities. Below is a comprehensive list of all publicly available APIs in Botpress. Each API has dedicated documentation section.

--- a/api-reference/pagination.mdx
+++ b/api-reference/pagination.mdx
@@ -1,3 +1,7 @@
+---
+title: Pagination
+---
+
 Our APIs return paginated results. Our paging is based on a cursor-based pagination system, which means that the API returns a set of results and a cursor (`nextToken`) that you can use to retrieve the next set of results. You can use this cursor in 2 ways:
 
 ## 1. Pagination with API Query Parameters

--- a/api-reference/ratelimiting.mdx
+++ b/api-reference/ratelimiting.mdx
@@ -1,3 +1,7 @@
+---
+title: Rate limiting
+---
+
 Our APIs are protected using a sliding window rate limiter. This means that exceeding the allowed number of requests per time window will result in a `429 Too Many Requests` (rate-limited) response.
 
 The rate limiter returns for each request the following headers:

--- a/desk/introduction.mdx
+++ b/desk/introduction.mdx
@@ -1,3 +1,7 @@
+---
+title: Desk
+---
+
 Desk is a **customer experience workspace for human-AI teams**. It combines a familiar interface with powerful AI-assisted tools, like:
 
 - Suggested answers to customer messages

--- a/get-started/configure-your-workspace.mdx
+++ b/get-started/configure-your-workspace.mdx
@@ -1,3 +1,7 @@
+---
+title: Configure your workspace
+---
+
 In Botpress, your workspace is the environment where you organize, manage, and collaborate on your agent projects.
 
 Each Workspace can contain multiple agents, so you can keep them organized by customer, department, or use case. Within a workspace, you can manage permissions, usage, billing, and more.

--- a/integrations/integration-guides/attio.mdx
+++ b/integrations/integration-guides/attio.mdx
@@ -1,4 +1,5 @@
 ---
+title: Attio
 description: Add a bot to Attio using the official integration.
 icon: '/integrations/integration-guides/assets/icons/attio.png'
 ---

--- a/integrations/integration-guides/gmail.mdx
+++ b/integrations/integration-guides/gmail.mdx
@@ -1,4 +1,5 @@
 ---
+title: Gmail
 icon: '/integrations/integration-guides/assets/icons/gmail.svg'
 ---
 

--- a/integrations/integration-guides/instagram.mdx
+++ b/integrations/integration-guides/instagram.mdx
@@ -1,4 +1,5 @@
 ---
+title: Instagram
 description: Add your bot to Instagram using the official integration.
 icon: '/integrations/integration-guides/assets/icons/instagram.svg'
 ---

--- a/integrations/integration-guides/klaviyo.mdx
+++ b/integrations/integration-guides/klaviyo.mdx
@@ -1,4 +1,5 @@
 ---
+title: Klaviyo
 description: Add a bot to Klaviyo using the official integration.
 icon: '/integrations/integration-guides/assets/icons/klaviyo.png'
 ---

--- a/integrations/integration-guides/pipedrive.mdx
+++ b/integrations/integration-guides/pipedrive.mdx
@@ -1,4 +1,5 @@
 ---
+title: Pipedrive
 description: Add a bot to Pipedrive using the official integration.
 icon: '/integrations/integration-guides/assets/icons/pipedrive.svg'
 ---

--- a/integrations/integration-guides/slack.mdx
+++ b/integrations/integration-guides/slack.mdx
@@ -1,4 +1,5 @@
 ---
+title: Slack
 description: Add a bot to Slack using the official integration.
 icon: '/integrations/integration-guides/assets/icons/slack.svg'
 ---

--- a/integrations/sdk/installation.mdx
+++ b/integrations/sdk/installation.mdx
@@ -1,3 +1,7 @@
+---
+title: Installation
+---
+
 To get started, install the Botpress CLI globally on your machine. The CLI includes the Botpress SDK and other useful packages for developing with Botpress.
 
 Run the following command in your terminal:

--- a/studio/concepts/cards/set-inactivity-timeout.mdx
+++ b/studio/concepts/cards/set-inactivity-timeout.mdx
@@ -1,3 +1,7 @@
+---
+title: Set inactivity timeout
+---
+
 You can use the Set Inactivity Timeout Card to **override the default inactivity timeout** configured in your [Bot Settings](/studio/concepts/bot-settings#inactivity-timeout).
 
 <Tip>

--- a/studio/concepts/cards/tables.mdx
+++ b/studio/concepts/cards/tables.mdx
@@ -1,3 +1,7 @@
+---
+title: Tables
+---
+
 You can use table Cards to perform operations on data you have stored in a table. This page contains a list of available table Cards.
 
 <Note>

--- a/studio/concepts/triggers.mdx
+++ b/studio/concepts/triggers.mdx
@@ -1,4 +1,5 @@
 ---
+title: Triggers
 icon: play
 ---
 

--- a/tutorial/basics/custom-logic/workflows.mdx
+++ b/tutorial/basics/custom-logic/workflows.mdx
@@ -1,3 +1,7 @@
+---
+title: Workflows
+---
+
 import { GoodToKnow } from '/snippets/tutorial/good-to-know.mdx'
 
 So far, we've only had our bot generate responses using AI. In practice, though, you might run into situations where you want your bot to perform some hard-coded logic.

--- a/tutorial/basics/first-steps/adding-knowledge.mdx
+++ b/tutorial/basics/first-steps/adding-knowledge.mdx
@@ -1,3 +1,7 @@
+---
+title: Adding knowledge
+---
+
 Now that our bot has a custom prompt, let's try asking it a question:
 
 <Frame>

--- a/tutorial/basics/first-steps/prompting.mdx
+++ b/tutorial/basics/first-steps/prompting.mdx
@@ -1,3 +1,7 @@
+---
+title: Prompting
+---
+
 In Botpress, an AI agent is a bot that follows a *prompt* (instructions) to respond to users.
 
 You can view your bot's prompt in Studio. After skipping the initial setup, select **Edit in Studio**. This opens Studio in a new tab—you'll see the prompt under **<Icon icon="list-checks"/> Instructions** at the top of the page. It should look something like this:

--- a/tutorial/basics/storing-information/assigning-a-value.mdx
+++ b/tutorial/basics/storing-information/assigning-a-value.mdx
@@ -1,3 +1,7 @@
+---
+title: Assigning a value
+---
+
 import { GoodToKnow } from '/snippets/tutorial/good-to-know.mdx'
 
 A newly-created variable is like an empty box—you need put something inside it before you can use it. This is called *assigning a value* to your variable.

--- a/tutorial/basics/storing-information/scoping-variables.mdx
+++ b/tutorial/basics/storing-information/scoping-variables.mdx
@@ -1,3 +1,7 @@
+---
+title: Scoping variables
+---
+
 import { GoodToKnow } from '/snippets/tutorial/good-to-know.mdx'
 
 Every variable has a *scope* that determines where and when your bot can access it.

--- a/tutorial/basics/storing-information/variables.mdx
+++ b/tutorial/basics/storing-information/variables.mdx
@@ -1,3 +1,7 @@
+---
+title: Variables
+---
+
 Sometimes, it's useful for your bot to remember some information—for example, about a specific user or conversation.
 
 You can do this using *variables*. A variable is a container that lets you store information from somewhere in Botpress Studio and reuse it somewhere else.

--- a/tutorial/introduction.mdx
+++ b/tutorial/introduction.mdx
@@ -1,4 +1,5 @@
 ---
+title: Introduction
 icon: chef-hat
 ---
 

--- a/webchat/react-library/components/composer.mdx
+++ b/webchat/react-library/components/composer.mdx
@@ -1,3 +1,7 @@
+---
+title: Composer
+---
+
 The `Composer` component is where the user writes messages before sending them to the bot. It provides a text area for input, file uploads, and a speech-to-text option.
 
 <Panel>

--- a/webchat/react-library/components/container.mdx
+++ b/webchat/react-library/components/container.mdx
@@ -1,3 +1,7 @@
+---
+title: Container
+---
+
 The `Container` wraps the core Webchat interface.
 It manages:
 

--- a/webchat/react-library/components/header.mdx
+++ b/webchat/react-library/components/header.mdx
@@ -1,3 +1,7 @@
+---
+title: Header
+---
+
 The `Header` component sits at the top of the Webchat UI. It displays the bot’s name, avatar, and description. It also provides access to key actions like restarting the conversation or closing the chat window.
 
 <Panel>

--- a/webchat/react-library/components/webchat.mdx
+++ b/webchat/react-library/components/webchat.mdx
@@ -1,3 +1,7 @@
+---
+title: Webchat
+---
+
 The `Webchat` component is a batteries-included implementation of the Webchat window. It contains most of what you'd expect when [injecting Webchat](/webchat/get-started/quick-start).
 
 <Panel>


### PR DESCRIPTION
Adds an explicitly set title to the frontmatter of any pages that didn't have it.

This is so the docs bot can grab the page's title when we switch over to `llms.txt` as the data source for its KB.