### PR TITLE
fix(integrations/chatwoot): remove self-hosting mention

### DIFF
--- a/integrations/integration-guides/chatwoot.mdx
+++ b/integrations/integration-guides/chatwoot.mdx
@@ -22,7 +22,7 @@ The official Chatwoot integration allows users to chat with your bot through Tel
   You will need:
 
   - A [published bot](/get-started/quick-start)
-  - A Chatwoot account ([self-hosted](https://developers.chatwoot.com/self-hosted) or [cloud](https://app.chatwoot.com/app/auth/signup?utm_source=navbar-link))
+  - A [Chatwoot account](https://app.chatwoot.com/app/auth/signup?utm_source=navbar-link)
 </Info>
 
 ### Step 1: Install the integration in Botpress


### PR DESCRIPTION
The Chatwoot documentation incorrectly mentioned self-hosted accounts. Currently, only the cloud version of Chatwoot is supported.

Closes #376 