### PR TITLE
fix: copy button on docs bot

### DIFF
--- a/assistant.js
+++ b/assistant.js
@@ -55,6 +55,7 @@
     iframe.style.width = '100%'
     iframe.style.height = '100%'
     iframe.src = 'https://botpress.github.io/docs-bot/'
+    iframe.allow = 'clipboard-write'
 
     botContainer.appendChild(iframe)
 


### PR DESCRIPTION
This should fix an issue on Chrome where the copy button wasn't working on code blocks sent by the docs assistant.