### PR TITLE
fix(webchat/settings): add team plan note for allowed origins

### DIFF
--- a/studio/guides/advanced/safety/preventing-abuse.mdx
+++ b/studio/guides/advanced/safety/preventing-abuse.mdx
@@ -4,13 +4,13 @@ title: Preventing Abuse
 
 At Botpress, we prioritize the security and integrity of your bots by implementing a range of robust measures to counteract fraud and malicious usage. Our strategy includes:
 
-### Rate Limits
+### Rate Limits {<Tooltip tip="This feature requires a Botpress Team plan or higher."><Badge stroke color="green">Team</Badge></Tooltip>}
 
 Rate limits serve as a fundamental safeguard for your bot's resources. Each bot is assigned a maximum rate of messages it can process per second. For users on the "Team" plan, a higher rate limit is applied. Enterprise customers can further customize these limits to align with their specific requirements.
 
 Rate limiting prevents the excessive influx of messages, ensuring that your bot operates efficiently and consistently. This is an essential component of our abuse prevention strategy.
 
-### Allowed Origins
+### Allowed Origins {<Tooltip tip="This feature requires a Botpress Team plan or higher."><Badge stroke color="green">Team</Badge></Tooltip>}
 
 Allowed Origins is a feature that lets you explicitly control where your bot is allowed to run by specifying a whitelist of approved domains. When deploying your bot on a website, you include only the domains that you trust, and the system automatically blocks any attempts to embed the bot from unapproved sources. This straightforward, security-first approach not only minimizes the risk of unauthorized use but also aligns with best practices for maintaining a secure, controlled deployment environment.
 

--- a/webchat/get-started/configure-your-webchat.mdx
+++ b/webchat/get-started/configure-your-webchat.mdx
@@ -272,3 +272,23 @@ Session storage creates a new user and conversation each time the page is re-ope
 You can [learn more about local and session storage here](https://www.geeksforgeeks.org/javascript/difference-between-local-storage-session-storage-and-cookies/).
 
 </Note>
+
+### Advanced settings
+
+You can also access the following advanced settings:
+
+#### Client ID
+
+The client ID is used to identify your bot's Webchat instance. You can use it when building with our [Webchat React library](/webchat/react-library/get-started).
+
+#### Allowed origins {<Tooltip tip="This feature requires a Botpress Team plan or higher."><Badge stroke color="green">Team</Badge></Tooltip>}
+
+The **Allowed Origins** setting lets you manage which domains are allowed to access Webchat.
+
+By default, this is set to **All Origins**. To restrict the allowed origins:
+
+<Steps>
+  <Step>Select **Whitelist**.</Step>
+  <Step>Select **+ Add Origin**.</Step>
+  <Step>Type the domain you want to allow, then select **Publish Changes**.</Step>
+</Steps>


### PR DESCRIPTION
Documents the Allowed Origins setting for Webchat and adds tooltips to indicate that it's only available for Team plans or higher.