### PR TITLE
fix(adk): typo and remove unimplemented data source

### DIFF
--- a/adk/concepts/knowledge.mdx
+++ b/adk/concepts/knowledge.mdx
@@ -123,7 +123,7 @@ export default new Knowledge({
 Index files from a local directory (development only):
 
 ```typescript
-const FileSource = DataSource.Directory.fromPath("/src/knowledge/docs", {
+const FileSource = DataSource.Directory.fromPath("./src/knowledge/docs", {
   filter: (filePath) => filePath.endsWith(".md") || filePath.endsWith(".txt"),
 });
 
@@ -144,7 +144,8 @@ export default new Knowledge({
 | `id` | `string` | Optional unique identifier for the source |
 | `filter` | `(filePath: string) => boolean` | Filter function to include/exclude files |
 
-### Table source
+{/* Temporarily removing as these are not yet implemented */}
+{/* ### Table source
 
 Index data from a table:
 
@@ -163,7 +164,7 @@ export default new Knowledge({
   name: "orders-kb",
   sources: [TableSource],
 });
-```
+``` */}
 
 ## Using knowledge in conversations
 


### PR DESCRIPTION
Fixes a typo with the code snippet for creating a KB data source from a local file.

Also comments out the section for creating KBs from tables, which hasn't yet been implemented