### PR TITLE
fix(integrations/whatsapp): update WhatsApp video link to 2026 version

### DIFF
--- a/integrations/integration-guides/whatsapp/introduction.mdx
+++ b/integrations/integration-guides/whatsapp/introduction.mdx
@@ -32,7 +32,7 @@ The official WhatsApp integration allows your users to chat with your bot by mes
     <Tip>
     Visual learner?
 
-    Check out our [WhatsApp guide](https://www.youtube.com/watch?v=qdFSwBwWG1Q) on YouTube for a step-by-step video guide.
+    Check out our [WhatsApp Setup guide](https://www.youtube.com/watch?v=Fs6dIxgEKoY) on YouTube for a step-by-step video guide.
     </Tip>
 
     <Steps>


### PR DESCRIPTION
Change link to the [2026 version](https://www.youtube.com/watch?v=Fs6dIxgEKoY):
<img width="677" height="118" alt="Screenshot 2026-02-20 at 3 18 17 PM" src="https://github.com/user-attachments/assets/73a1bfac-0ecb-4a2c-bcf5-80dcd9d71589" />


