### PR TITLE
feat(integrations/sdk): add bot secrets support and bump @botpress/api to 1.82.0

### DIFF
--- a/admin-openapi.json
+++ b/admin-openapi.json
@@ -8,7 +8,7 @@
   "info": {
     "title": "Botpress Admin API",
     "description": "API for Botpress Cloud Manager",
-    "version": "1.80.0"
+    "version": "1.82.0"
   },
   "paths": {
     "/v1/admin/helper/vrl": {
@@ -2852,6 +2852,52 @@
         "x-mint": {
           "metadata": {
             "title": "updateBotAllowlist"
+          }
+        },
+        "x-hidden": true,
+        "tags": [
+          "Endpoints"
+        ]
+      }
+    },
+    "/v1/admin/workspaces/{id}/migrate-to-v4": {
+      "post": {
+        "operationId": "migrateWorkspaceToV4",
+        "description": "Migrate a workspace from v3 to v4 billing. Not meant for public use.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workspace ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-multiple-integrations",
+            "in": "header",
+            "description": "Whether the client supports bots with multiple instances of the same integration. Set to \"true\" to receive integration instances keyed by their alias instead of their id. This header will be removed in the future, and the API will always return multiple instances keyed by alias.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/migrateWorkspaceToV4Response"
+          },
+          "default": {
+            "$ref": "#/components/responses/migrateWorkspaceToV4Response"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/migrateWorkspaceToV4Body"
+        },
+        "x-mint": {
+          "metadata": {
+            "title": "migrateWorkspaceToV4"
           }
         },
         "x-hidden": true,
@@ -6965,6 +7011,13 @@
             "type": "boolean",
             "description": "Indicates if the [Bot](#schema_bot) is a development bot; Development bots run locally and can install dev integrations"
           },
+          "secrets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of secret names configured for this [Bot](#schema_bot)"
+          },
           "createdBy": {
             "type": "string",
             "description": "Id of the user that created the bot"
@@ -7023,6 +7076,7 @@
           "tags",
           "name",
           "dev",
+          "secrets",
           "alwaysAlive",
           "status",
           "medias"
@@ -13965,6 +14019,18 @@
           }
         }
       },
+      "migrateWorkspaceToV4Response": {
+        "description": "Success",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "title": "migrateWorkspaceToV4Response",
+              "additionalProperties": false
+            }
+          }
+        }
+      },
       "listWorkspaceInvoicesResponse": {
         "description": "Success",
         "content": {
@@ -17022,6 +17088,14 @@
                   "type": "string",
                   "description": "URL of the [Bot](#schema_bot)"
                 },
+                "secrets": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string",
+                    "maxLength": 20000
+                  },
+                  "description": "Secrets are values available in the code via environment variables formatted with a SECRET_ prefix followed by your secret name. A secret name must respect SCREAMING_SNAKE casing."
+                },
                 "dev": {
                   "type": "boolean",
                   "description": "Indicates if the [Bot](#schema_bot) is a development bot; Development bots run locally and can install dev integrations"
@@ -17492,6 +17566,15 @@
                   },
                   "description": "Media files associated with the [Bot](#schema_bot)"
                 },
+                "secrets": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string",
+                    "maxLength": 20000,
+                    "nullable": true
+                  },
+                  "description": "Secrets are values available in the code via environment variables formatted with a SECRET_ prefix followed by your secret name. A secret name must respect SCREAMING_SNAKE casing."
+                },
                 "layers": {
                   "type": "array",
                   "items": {
@@ -17666,6 +17749,18 @@
                 }
               },
               "title": "updateBotAllowlistBody",
+              "additionalProperties": false
+            }
+          }
+        }
+      },
+      "migrateWorkspaceToV4Body": {
+        "description": "No body required; migration uses workspace id only.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "title": "migrateWorkspaceToV4Body",
               "additionalProperties": false
             }
           }

--- a/files-openapi.json
+++ b/files-openapi.json
@@ -8,7 +8,7 @@
   "info": {
     "title": "Botpress Files API",
     "description": "API for Botpress Files",
-    "version": "1.80.0"
+    "version": "1.82.0"
   },
   "paths": {
     "/v1/files": {

--- a/integrations/sdk/cli-reference.mdx
+++ b/integrations/sdk/cli-reference.mdx
@@ -148,7 +148,7 @@ bp serve --port 8080 --secrets SECRET1=value1 SECRET2=value2
 |------|-------------|---------|
 | `--work-dir` | Path to the project | current directory |
 | `--port` | Port to use | |
-| `--secrets` | Values for integration secrets (array) | |
+| `--secrets` | Values for bot and integration secrets (array) | |
 
 ---
 
@@ -170,7 +170,7 @@ bp dev --port 3000 --secrets API_KEY=secret123
 | `--api-url` | Botpress server URL | |
 | `--workspace-id` | Workspace ID | |
 | `--token` | Personal Access Token | |
-| `--secrets` | Values for integration secrets (array) | |
+| `--secrets` | Values for bot and integration secrets (array) | |
 | `--source-map` | Generate sourcemaps | false |
 | `--minify` | Minify the bundled code | true |
 | `--port` | Port to use | |
@@ -197,7 +197,7 @@ bp deploy --create-new-bot --no-build
 | `--api-url` | Botpress server URL | |
 | `--workspace-id` | Workspace ID | |
 | `--token` | Personal Access Token | |
-| `--secrets` | Values for integration secrets (array) | |
+| `--secrets` | Values for bot and integration secrets (array) | |
 | `--bot-id` | Bot ID to deploy (only for bots) | |
 | `--no-build` | Skip the build step | false |
 | `--dry-run` | Ask API not to perform actual operation | false |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "generate-api-reference": "ts-node generate-api-reference.ts"
   },
   "dependencies": {
-    "@botpress/api": "1.80.0",
+    "@botpress/api": "1.82.0",
     "glob": "11.0.1",
     "mintlify": "^4.0.461",
     "optional": "^0.1.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@botpress/api':
-        specifier: 1.80.0
-        version: 1.80.0(openapi-types@12.1.3)
+        specifier: 1.82.0
+        version: 1.82.0(openapi-types@12.1.3)
       glob:
         specifier: 11.0.1
         version: 11.0.1
@@ -81,8 +81,8 @@ packages:
     resolution: {integrity: sha512-E/jKbPoca1tfUPj3iSbitDZTGnq6FUFjkH6L8U2oDwSuwK1WhnnVtCG7oFOTg/DDnyoXbQYUiUiGOibHqaGVnw==}
     engines: {node: '>= 16'}
 
-  '@botpress/api@1.80.0':
-    resolution: {integrity: sha512-2XvtI5xoV+QMW88C1+iL38f3vcor4h9htc4i0+ZT68a2GiFeEwKeIXc0P8rIb64s4xNra3izrR7sbEjOsSnBhQ==}
+  '@botpress/api@1.82.0':
+    resolution: {integrity: sha512-X1l1Vq+t/ZVMqPeKexHf9vrPkIRmN7ct4sEOo5eAcRKSxb3Ksvxbo/XmDvZQEb0sxl4AcMSVOuo0WenUBJ9gWw==}
 
   '@bpinternal/opapi@1.0.0':
     resolution: {integrity: sha512-r38k8SZSyu0s4YKukTrHaBeb8tlL8vgJiNdawnN2cmxbqkSdsss2pWnZQU2fsSLijhcfV0tUvGCf8GfgZviYBA==}
@@ -4433,7 +4433,7 @@ snapshots:
       call-me-maybe: 1.0.2
       js-yaml: 4.1.1
 
-  '@botpress/api@1.80.0(openapi-types@12.1.3)':
+  '@botpress/api@1.82.0(openapi-types@12.1.3)':
     dependencies:
       '@bpinternal/opapi': 1.0.0(openapi-types@12.1.3)
     transitivePeerDependencies:
@@ -5539,7 +5539,7 @@ snapshots:
       dependency-graph: 0.11.0
       fast-memoize: 2.5.2
       immer: 9.0.21
-      lodash: 4.17.21
+      lodash: 4.17.23
       tslib: 2.8.1
       urijs: 1.19.11
 
@@ -5549,7 +5549,7 @@ snapshots:
       '@stoplight/path': 1.3.2
       '@stoplight/types': 13.20.0
       jsonc-parser: 2.2.1
-      lodash: 4.17.21
+      lodash: 4.17.23
       safe-stable-stringify: 1.1.1
 
   '@stoplight/ordered-object-literal@1.0.5': {}
@@ -5602,7 +5602,7 @@ snapshots:
       ajv-draft-04: 1.0.0(ajv@8.18.0)
       ajv-errors: 3.0.0(ajv@8.18.0)
       ajv-formats: 2.1.1(ajv@8.18.0)
-      lodash: 4.17.21
+      lodash: 4.17.23
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding

--- a/runtime-openapi.json
+++ b/runtime-openapi.json
@@ -8,7 +8,7 @@
   "info": {
     "title": "Botpress Runtime API",
     "description": "API for Botpress Runtime",
-    "version": "1.80.0"
+    "version": "1.82.0"
   },
   "paths": {
     "/v1/chat/conversations": {

--- a/tables-openapi.json
+++ b/tables-openapi.json
@@ -8,7 +8,7 @@
   "info": {
     "title": "Botpress Tables API",
     "description": "API for Botpress Tables",
-    "version": "1.80.0"
+    "version": "1.82.0"
   },
   "paths": {
     "/v1/tables": {


### PR DESCRIPTION
## Summary
- Added `secrets` field to Bot schema in admin-openapi.json (list of secret names configured for a bot)
- Added `secrets` object to create/update bot request bodies (SCREAMING_SNAKE cased env vars with `SECRET_` prefix)
- Added `migrateWorkspaceToV4` endpoint in admin-openapi.json
- Updated CLI reference `--secrets` description to include "bot and integration secrets"
- Bumped `@botpress/api` from 1.80.0 to 1.82.0

## Test plan
- [x] Verify bot secrets field appears correctly in API reference docs
- [x] Verify CLI reference `--secrets` flag description is accurate for both bots and integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)