### PR TITLE
chore(integrations/sdk): remove extra button under SDK --> Overview

### DIFF
--- a/integrations/sdk/overview.mdx
+++ b/integrations/sdk/overview.mdx
@@ -24,14 +24,9 @@ Integrations connect bots to external services and platforms, enabling communica
 - Perform operations on behalf of users in external systems
 - Trigger events in your bots based on actions in external services
 
-<CardGroup Cols={2}>
-    <Card title="Read more" horizontal icon="book" href="/integrations/sdk/integration/getting-started">
-        Learn more about integrations
-    </Card>
-    <Card title="Getting started" horizontal icon="play" href="/integrations/sdk/integration/getting-started">
-        Create your first integration
-    </Card>
-</CardGroup>
+<Card title="Getting started" horizontal icon="play" href="/integrations/sdk/integration/getting-started">
+    Create your first integration
+</Card>
 
 ### Interfaces
 


### PR DESCRIPTION
Both buttons led to the same page, just left one of them. Pointed out by Solutions team

Before:
<img width="1408" height="974" alt="image" src="https://github.com/user-attachments/assets/755e1811-b073-4352-8a36-00a7984c6bfe" />

After:
<img width="731" height="491" alt="Screenshot 2026-03-20 at 4 29 18 PM" src="https://github.com/user-attachments/assets/eac9e360-bb6a-48df-9b7f-e427f3297610" />
