### PR TITLE
chore(execute-code): Add to Execute Code doc

### DIFF
--- a/studio/concepts/cards/execute-code.mdx
+++ b/studio/concepts/cards/execute-code.mdx
@@ -7,8 +7,9 @@ The Execute Code Card lets you **run custom [JavaScript](https://developer.mozil
 You can use the Execute Code Card to extend the functionality of your bot beyond Studio's built-in Cards. For example, you can:
 
 - Perform complex calculations
-- Manipulate data and variables
+- Manipulate data and variables (see [variables in code](/studio/concepts/variables/in-code))
 - Call external APIs
+- Add guardrails such as custom error handling, rate limits, permission checks, and fallbacks
 
 <Note>
     Execute Code Cards allow you to generate one-time code snippets at specific points in your Workflow. For reusable code snippets, use [Actions](/studio/concepts/actions).
@@ -38,3 +39,9 @@ The Execute Code card allows you to generate code using AI, so you don't have to
 </Frame>
 
 At the top of the code editor, write a prompt and hit enter to generate code using AI. You can then edit this code manually or ask AI to make revisions to it.
+
+<Note>
+
+    Review AI-generated code before production. Store secrets in [configuration variables](/studio/concepts/variables/scopes/configuration) (use `env` in code), and handle slow or failed requests with `try`/`catch`, timeouts, or fallback flows.
+
+</Note>


### PR DESCRIPTION
Converting blogs to docs.

Reference: [Execute Code Card](https://botpress.com/blog/execute-code-card)