### PR TITLE
fix(bot): update workflow pnpm version to match CI check

### DIFF
--- a/.github/workflows/update-integrations.yml
+++ b/.github/workflows/update-integrations.yml
@@ -27,9 +27,9 @@ jobs:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v4.1.0
         with:
-          version: 8.6.2
+          version: 10.32.1
 
       - name: Install main dependencies
         run: pnpm install


### PR DESCRIPTION
Conflicting versions caused automatic PR for weekly workflow in updating integrations to not pass CI checks. Needed to update to match the one in [run-checks.yaml](https://github.com/botpress/docs/blob/master/.github/workflows/run-checks.yml)