### PR TITLE
chore(autonomous-nodes): add examples to autonomous node docs

### DIFF
--- a/studio/concepts/nodes/autonomous-node.mdx
+++ b/studio/concepts/nodes/autonomous-node.mdx
@@ -187,7 +187,7 @@ You can view a full list of tools your bot currently has access to in the [Inspe
     title="Example: Keep knowledge and web search on-topic"
     >
 
-    This prompt narrows when each search tool runs so the Node does not pull unrelated content:
+    This prompt narrows when each search tool runs so the Node doesn't pull unrelated content:
 
     ```markdown Instructions wrap
     **Tool boundaries**
@@ -200,7 +200,7 @@ You can view a full list of tools your bot currently has access to in the [Inspe
     title="Example: Video link with a timestamp"
     >
 
-    When the base URL lives in a [workflow variable](/studio/concepts/variables/scopes/workflow), this prompt tells the Autonomous Node how to add a start time (replace the variable name with one you have given the Node access to):
+    When the base URL lives in a [Workflow variable](/studio/concepts/variables/scopes/workflow), this prompt tells the Autonomous Node how to add a start time (replace the variable name with one you have given the Node access to):
 
     ```markdown Instructions wrap
     **Video links**
@@ -231,7 +231,7 @@ You can view a full list of tools your bot currently has access to in the [Inspe
     This pattern is for leaving the Autonomous Node for a structured sub-Workflow after saving a value from the conversation. The Autonomous Node needs [read and write access](#give-access-to-variables) to the variable you mention:
 
     ```markdown Instructions wrap
-    When the user asks for deeper details about an email they mentioned, use `workflow.transition` to move to the **Enrich contact** node. Before transitioning, set `workflow.requestedEmail` to that email address.
+    When the user asks for deeper details about an email they mentioned, use `workflow.transition` to move to the **Enrich contact** Node. Before transitioning, set `workflow.requestedEmail` to that email address.
     ```
 
     Replace the node name, variable name, and trigger phrase with whatever matches your bot.

--- a/studio/concepts/nodes/autonomous-node.mdx
+++ b/studio/concepts/nodes/autonomous-node.mdx
@@ -234,14 +234,14 @@ You can view a full list of tools your bot currently has access to in the [Inspe
     When the user asks for deeper details about an email they mentioned, use `workflow.transition` to move to the **Enrich contact** Node. Before transitioning, set `workflow.requestedEmail` to that email address.
     ```
 
-    Replace the node name, variable name, and trigger phrase with whatever matches your bot.
+    Replace the Node name, variable name, and trigger phrase with whatever matches your bot.
     </Accordion>
 
     <Accordion
     title="Example: Menu choice, then transition"
     >
 
-    This prompt combines `global.Message` with `workflow.transition` when the user picks a numeric option. Connect each option with another Node in your Workflow first so `workflow.transition` is valid:
+    This prompt combines `global.Message` with `workflow.transition` when the user picks a numeric option. Connect each target with a **Transition** card on the canvas first so `workflow.transition` is valid:
 
     ```markdown Instructions wrap
     If the user sends **1**, thank them briefly with `global.Message`, then use `workflow.transition` to go to the **Self-serve** node. If they send **2**, use `workflow.transition` to go to the **Guided setup** node.

--- a/studio/concepts/nodes/autonomous-node.mdx
+++ b/studio/concepts/nodes/autonomous-node.mdx
@@ -182,6 +182,31 @@ You can view a full list of tools your bot currently has access to in the [Inspe
     If you can't answer the user's question with `global.search`, use `browser.webSearch`.
     ```
   </Accordion>
+
+    <Accordion
+    title="Example: Keep knowledge and web search on-topic"
+    >
+
+    This prompt narrows when each search tool runs so the Node does not pull unrelated content:
+
+    ```markdown Instructions wrap
+    **Tool boundaries**
+    - Use `global.search` only for questions about [your scoped topic—for example course content or order support]. Do **not** use it for general pricing, marketing, or unrelated small talk unless the user explicitly needs a documented policy from the knowledge base.
+    - Use `browser.webSearch` only when `global.search` does not contain a sufficient answer **and** the question still falls within that same scope. Do not use web search for out-of-scope requests—politely decline instead.
+    ```
+  </Accordion>
+
+    <Accordion
+    title="Example: Video link with a timestamp"
+    >
+
+    When the base URL lives in a [workflow variable](/studio/concepts/variables/scopes/workflow), this prompt tells the Autonomous Node how to add a start time (replace the variable name with one you have given the Node access to):
+
+    ```markdown Instructions wrap
+    **Video links**
+    If the user wants a link to the lesson video, the base URL is in `workflow.contentLinks`. To jump to a specific second, append a `t` query in seconds (e.g. 15 seconds → add `?t=15` or `&t=15` depending on whether the URL already has query parameters).
+    ```
+  </Accordion>
   </Tab>
   <Tab title="Transition tools">
     Here are the tools your bot uses to make transitions:
@@ -197,6 +222,30 @@ You can view a full list of tools your bot currently has access to in the [Inspe
       ```markdown Instructions wrap
       When the user wants to checkout with their current cart, use `global.checkout`.
       ```
+    </Accordion>
+
+    <Accordion
+    title="Example: Transition and set a variable"
+    >
+
+    This pattern is for leaving the Autonomous Node for a structured sub-Workflow after saving a value from the conversation. The Autonomous Node needs [read and write access](#give-access-to-variables) to the variable you mention:
+
+    ```markdown Instructions wrap
+    When the user asks for deeper details about an email they mentioned, use `workflow.transition` to move to the **Enrich contact** node. Before transitioning, set `workflow.requestedEmail` to that email address.
+    ```
+
+    Replace the node name, variable name, and trigger phrase with whatever matches your bot.
+    </Accordion>
+
+    <Accordion
+    title="Example: Menu choice, then transition"
+    >
+
+    This prompt combines `global.Message` with `workflow.transition` when the user picks a numeric option. Connect each target with a **Transition** card on the canvas first so `workflow.transition` is valid:
+
+    ```markdown Instructions wrap
+    If the user sends **1**, thank them briefly with `global.Message`, then use `workflow.transition` to go to the **Self-serve** node. If they send **2**, use `workflow.transition` to go to the **Guided setup** node.
+    ```
     </Accordion>
 
   </Tab>

--- a/studio/concepts/nodes/autonomous-node.mdx
+++ b/studio/concepts/nodes/autonomous-node.mdx
@@ -241,7 +241,7 @@ You can view a full list of tools your bot currently has access to in the [Inspe
     title="Example: Menu choice, then transition"
     >
 
-    This prompt combines `global.Message` with `workflow.transition` when the user picks a numeric option. Connect each target with a **Transition** card on the canvas first so `workflow.transition` is valid:
+    This prompt combines `global.Message` with `workflow.transition` when the user picks a numeric option. Connect each option with another Node in your Workflow first so `workflow.transition` is valid:
 
     ```markdown Instructions wrap
     If the user sends **1**, thank them briefly with `global.Message`, then use `workflow.transition` to go to the **Self-serve** node. If they send **2**, use `workflow.transition` to go to the **Guided setup** node.


### PR DESCRIPTION
Converting blog [A Solution Engineer's Guide to Autonomous Nodes](https://botpress.com/blog/autonomous-nodes) to docs

Just adding extra examples for instruction prompt that the blog covers but is not in docs

