### PR TITLE
docs(adk-v2): setting up your agent section

### DIFF
--- a/adk/setting-up-your-agent/agent-configuration.mdx
+++ b/adk/setting-up-your-agent/agent-configuration.mdx
@@ -1,0 +1,6 @@
+---
+title: Agent configuration
+description: Configure your agent's identity, models, state, and dependencies.
+---
+
+Coming soon.

--- a/adk/setting-up-your-agent/environment-setup.mdx
+++ b/adk/setting-up-your-agent/environment-setup.mdx
@@ -1,0 +1,6 @@
+---
+title: Environment setup
+description: Set up profiles, environments, and multi-developer workflows.
+---
+
+Coming soon.

--- a/adk/setting-up-your-agent/integrations.mdx
+++ b/adk/setting-up-your-agent/integrations.mdx
@@ -1,0 +1,6 @@
+---
+title: Integrations
+description: Discover, install, and configure Botpress integrations in your ADK project.
+---
+
+Coming soon.

--- a/docs.json
+++ b/docs.json
@@ -93,6 +93,14 @@
               "/adk/quickstart",
               "/adk/project-structure",
               {
+                "group": "Setting up your agent",
+                "pages": [
+                  "/adk/setting-up-your-agent/agent-configuration",
+                  "/adk/setting-up-your-agent/environment-setup",
+                  "/adk/setting-up-your-agent/integrations"
+                ]
+              },
+              {
                 "group": "Concepts",
                 "pages": [
                   "/adk/concepts/conversations",


### PR DESCRIPTION
## Summary

Scaffolds the Setting up your agent section of the ADK docs with three placeholder pages: Agent configuration, Environment setup, and Integrations. Adds a nested Setting up your agent group to the ADK sidebar between Get started and Concepts. Content fills in follow-up commits.

## Test plan

Open the preview and walk through the three placeholder pages under Setting up your agent in the ADK sidebar.