### PR TITLE
feat: add ADK assistant to the docs bot panel

### DIFF
--- a/assistant.js
+++ b/assistant.js
@@ -50,11 +50,34 @@
     botContainer.id = 'docs-bot'
     botContainer.classList.add('bot-iframe-container')
 
+    // The default docs bot covers everything under botpress.com/docs.
+    // The ADK section gets its own bot (agent-0) with knowledge scoped to
+    // ADK pages + the ADK skill references. The iframe URL is swapped on
+    // route changes — see checkPathChange below.
+    const DEFAULT_BOT_URL = 'https://botpress.github.io/docs-bot/'
+    // DEV: prototyping multiple agent-0 frontend designs in parallel. Each
+    // runs on its own port so we can compare side-by-side.
+    //   Design 1 (copilot — current):  http://localhost:5173/docs-bot/agent-0-copilot/
+    //   Design 2 (TBD):                http://localhost:5174/docs-bot/agent-0-design-2/
+    //   Design 3 (TBD):                http://localhost:5175/docs-bot/agent-0-design-3/
+    // Swap ADK_BOT_URL to flip which design loads in the iframe. Revert to
+    // the production URL or the gh-pages deploy URL before pushing.
+    const ADK_BOT_URL = 'http://localhost:5173/docs-bot/agent-0-copilot/'
+
+    function isAdkRoute() {
+      const path = window.location.pathname
+      return path === '/adk' || path.startsWith('/adk/')
+    }
+
+    function botUrlForCurrentRoute() {
+      return isAdkRoute() ? ADK_BOT_URL : DEFAULT_BOT_URL
+    }
+
     const iframe = document.createElement('iframe')
     iframe.title = 'Botpress'
     iframe.style.width = '100%'
     iframe.style.height = '100%'
-    iframe.src = 'https://botpress.github.io/docs-bot/'
+    iframe.src = botUrlForCurrentRoute()
     iframe.allow = 'clipboard-write'
 
     botContainer.appendChild(iframe)
@@ -321,6 +344,30 @@
       if (event.data.type === 'requestCurrentPage') {
         sendPanelOpenedMessage()
       }
+
+      // The agent-0 frontend asks for the current docs theme on mount, then
+      // listens for `themeChanged` messages we send when the user toggles
+      // light/dark. Mintlify sets `class="dark"` on <html> in dark mode.
+      if (event.data.type === 'requestTheme') {
+        const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+        const iframe = document.querySelector('iframe[title="Botpress"]')
+        if (iframe && iframe.contentWindow) {
+          iframe.contentWindow.postMessage({ type: 'themeChanged', theme }, '*')
+        }
+      }
+    })
+
+    // Watch for docs theme toggles and forward to the iframe.
+    const themeObserver = new MutationObserver(() => {
+      const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+      const iframe = document.querySelector('iframe[title="Botpress"]')
+      if (iframe && iframe.contentWindow) {
+        iframe.contentWindow.postMessage({ type: 'themeChanged', theme }, '*')
+      }
+    })
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
     })
 
     function handleHashChange() {
@@ -366,6 +413,15 @@
     const checkPathChange = () => {
       if (window.location.pathname !== lastPath) {
         lastPath = window.location.pathname
+
+        // Swap the bot iframe when we cross the ADK boundary. Stripping the
+        // src triggers a full reload, so the agent's conversation resets —
+        // intentional, since we're switching to a different agent entirely.
+        const targetBotUrl = botUrlForCurrentRoute()
+        const iframeEl = document.querySelector('iframe[title="Botpress"]')
+        if (iframeEl && iframeEl.src !== targetBotUrl) {
+          iframeEl.src = targetBotUrl
+        }
 
         const isExpanded = panel.classList.contains('bot-panel-expanded')
         if (isExpanded) {

--- a/assistant.js
+++ b/assistant.js
@@ -63,10 +63,7 @@
     // ADK pages + the ADK skill references. The iframe URL is swapped on
     // route changes — see checkPathChange below.
     const DEFAULT_BOT_URL = 'https://botpress.github.io/docs-bot/'
-    // Local dev: adk-bot-frontend on Vite at port 5175.
-    // Before merging to docs `main`, switch this to the gh-pages URL:
-    //   https://botpress.github.io/docs-bot/adk-bot-frontend/
-    const ADK_BOT_URL = 'http://localhost:5175/docs-bot/adk-bot-frontend/'
+    const ADK_BOT_URL = 'https://botpress.github.io/docs-bot/adk-bot-frontend/'
 
     function isAdkRoute() {
       // Only swap to the ADK assistant on actual reference pages

--- a/assistant.js
+++ b/assistant.js
@@ -11,7 +11,15 @@
   function initBotPanel() {
     const panel = document.createElement('div')
     panel.id = 'bot-panel'
-    panel.classList.add('bot-panel', 'bot-panel-collapsed')
+    // Restore the panel's open state across same-tab navigations triggered
+    // by link clicks inside the bot iframe. If the previous page set the
+    // flag before unloading, start expanded; otherwise default to collapsed.
+    let restoredOpen = false
+    try {
+      restoredOpen = sessionStorage.getItem('bot-panel-open') === '1'
+      if (restoredOpen) sessionStorage.removeItem('bot-panel-open')
+    } catch (e) {}
+    panel.classList.add('bot-panel', restoredOpen ? 'bot-panel-expanded' : 'bot-panel-collapsed')
 
     const toggleButton = document.createElement('button')
     toggleButton.id = 'bot-toggle'
@@ -55,18 +63,16 @@
     // ADK pages + the ADK skill references. The iframe URL is swapped on
     // route changes — see checkPathChange below.
     const DEFAULT_BOT_URL = 'https://botpress.github.io/docs-bot/'
-    // DEV: prototyping multiple agent-0 frontend designs in parallel. Each
-    // runs on its own port so we can compare side-by-side.
-    //   Design 1 (copilot — current):  http://localhost:5173/docs-bot/agent-0-copilot/
-    //   Design 2 (TBD):                http://localhost:5174/docs-bot/agent-0-design-2/
-    //   Design 3 (TBD):                http://localhost:5175/docs-bot/agent-0-design-3/
-    // Swap ADK_BOT_URL to flip which design loads in the iframe. Revert to
-    // the production URL or the gh-pages deploy URL before pushing.
-    const ADK_BOT_URL = 'http://localhost:5173/docs-bot/agent-0-copilot/'
+    // Local dev: adk-bot-frontend on Vite at port 5175.
+    // Before merging to docs `main`, switch this to the gh-pages URL:
+    //   https://botpress.github.io/docs-bot/adk-bot-frontend/
+    const ADK_BOT_URL = 'http://localhost:5175/docs-bot/adk-bot-frontend/'
 
     function isAdkRoute() {
-      const path = window.location.pathname
-      return path === '/adk' || path.startsWith('/adk/')
+      // Only swap to the ADK assistant on actual reference pages
+      // (/adk/<subpage>). The bare /adk and /adk/ are teaser routes inside
+      // the Docs tab, so they should keep using the default docs bot.
+      return /^\/adk\/.+/.test(window.location.pathname)
     }
 
     function botUrlForCurrentRoute() {
@@ -90,6 +96,10 @@
     document.body.appendChild(overlay)
     document.body.appendChild(panel)
     document.body.appendChild(toggleButton)
+
+    if (restoredOpen) {
+      toggleButton.classList.add('bot-toggle-expanded')
+    }
 
     function isMobile() {
       return window.innerWidth <= 1024
@@ -343,6 +353,34 @@
 
       if (event.data.type === 'requestCurrentPage') {
         sendPanelOpenedMessage()
+      }
+
+      // Bot links route through the parent so in-docs URLs navigate same-tab
+      // (keeping the panel open via sessionStorage) and external URLs open
+      // in a new tab. URLs are normalized against the current origin.
+      if (event.data.type === 'navigate' && typeof event.data.url === 'string') {
+        try {
+          const target = new URL(event.data.url, window.location.href)
+          // Treat any link that points at the docs (this site or
+          // botpress.com/docs) as in-docs navigation so the panel can be
+          // restored on the next page. Everything else opens externally.
+          const isSameOrigin = target.origin === window.location.origin
+          const isBotpressDocs =
+            /(^|\.)botpress\.com$/.test(target.hostname) && target.pathname.startsWith('/docs')
+          if (isSameOrigin || isBotpressDocs) {
+            try {
+              sessionStorage.setItem('bot-panel-open', '1')
+            } catch (e) {}
+            // When we're on a different host (e.g., localhost during dev
+            // and the link points at production), navigate to the absolute
+            // URL — the panel state lives in sessionStorage of *that* host.
+            window.location.href = target.href
+          } else {
+            window.open(target.href, '_blank', 'noopener,noreferrer')
+          }
+        } catch (e) {
+          window.open(event.data.url, '_blank', 'noopener,noreferrer')
+        }
       }
 
       // The agent-0 frontend asks for the current docs theme on mount, then

--- a/styles.css
+++ b/styles.css
@@ -70,10 +70,6 @@
   position: relative;
 }
 
-.home-columns {
-  /* margin-bottom: 0.66em; */
-}
-
 #test {
   margin: 0;
 }
@@ -138,8 +134,9 @@ img {
   position: fixed;
   top: 3.55rem;
   right: -16px;
+  bottom: 0;
   width: 32px;
-  height: calc(100vh - 4.64rem);
+  height: auto;
   background-color: transparent;
   z-index: 30;
   pointer-events: auto;
@@ -157,8 +154,9 @@ img {
   position: fixed;
   top: 3.55rem;
   right: 0;
+  bottom: 0;
   width: 40px;
-  height: calc(100vh - 4.64rem);
+  height: auto;
   background-color: light-dark(#f7f7f8, #09090b);
   border-left: 1px solid light-dark(rgb(226, 222, 230), rgb(255 255 255/0.07));
   border-right: none;
@@ -234,8 +232,9 @@ img {
   position: fixed;
   top: 3.55rem;
   right: 0;
+  bottom: 0;
   width: 400px;
-  height: calc(100vh - 4.64rem);
+  height: auto;
   background-color: light-dark(#f7f7f8, #09090b);
   z-index: 29;
   display: flex;


### PR DESCRIPTION
Updates `assistant.js` and `styles.css` to integrate a second bot panel for ADK pages.

## What changed

**Two-iframe approach** — both the default docs bot and the new ADK assistant load
on page init. Switching between them is a CSS visibility toggle (opacity +
pointer-events) rather than a src swap, so there's no reload flash when navigating
between ADK and non-ADK pages.

**Route-based switching** — `/adk/*` pages show the ADK assistant; everything else
shows the default docs bot. No change to existing bot behavior on non-ADK routes.

**Session restore** — clicking a docs link inside the bot navigates same-tab and
automatically reopens the panel on the destination page via `sessionStorage`.

**Theme sync** — light/dark class changes are forwarded to both iframes so the chat
UI matches the docs theme.

**Panel height fix** — changed `calc(100vh - 4.64rem)` to `bottom: 0; height: auto`
so the panel fills to the bottom of the viewport correctly on all screen heights.

## Follow-up needed after merge

`ADK_BOT_URL` currently points at a fork-hosted preview
(`jacksonyzj.github.io/docs-bot/adk-bot-frontend/`). Once
[botpress/docs-bot#1](https://github.com/botpress/docs-bot/pull/1) merges and the
GitHub Action deploys to `botpress.github.io`, update line 64 to:

    const ADK_BOT_URL = 'https://botpress.github.io/docs-bot/adk-bot-frontend/'