### PR TITLE
fix: ADK bot not loading on live site (wrong pathname regex)

### DIFF
--- a/assistant.js
+++ b/assistant.js
@@ -66,10 +66,9 @@
     const ADK_BOT_URL = 'https://botpress.github.io/docs-bot/adk-bot-frontend/'
 
     function isAdkRoute() {
-      // Only swap to the ADK assistant on actual reference pages
-      // (/adk/<subpage>). The bare /adk and /adk/ are teaser routes inside
-      // the Docs tab, so they should keep using the default docs bot.
-      return /^\/adk\/.+/.test(window.location.pathname)
+      // Match /docs/adk/<subpage> on the live site (pathname includes /docs/ prefix).
+      // The bare /adk and /adk/ teaser routes keep using the default docs bot.
+      return /\/adk\/.+/.test(window.location.pathname)
     }
 
     function botUrlForCurrentRoute() {


### PR DESCRIPTION
## Summary
- `isAdkRoute()` used `^\/adk\/.+` but the live site serves pages at `/docs/adk/...`, so the anchored regex never matched and the default bot loaded instead of the ADK bot
- Dropping the `^` anchor so the regex matches anywhere in the pathname fixes it

## Test plan
- [ ] Visit `https://botpress.com/docs/adk/introduction` — ADK bot iframe loads in the right panel