### PR TITLE
chore(adk): hide Quickstart with Cursor page from nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -451,8 +451,7 @@
             "group": "Get started",
             "pages": [
               "/adk/introduction",
-              "/adk/quickstart",
-              "/adk/quickstart-ai-assistant"
+              "/adk/quickstart"
             ]
           },
           {


### PR DESCRIPTION
Removes the Quickstart with Cursor page from the sidebar nav post-hackathon. The file stays on disk.