### PR TITLE
fix(adk): clarify browser integration for JS-rendered sites

### DIFF
--- a/adk/data/knowledge.mdx
+++ b/adk/data/knowledge.mdx
@@ -71,7 +71,7 @@ const DocsSource = DataSource.Website.fromSitemap(
 
 ### Website from base URL
 
-Crawl a website starting from a URL (requires the Browser integration):
+Crawl a website starting from a URL:
 
 ```typescript
 const DocsSource = DataSource.Website.fromWebsite(
@@ -82,6 +82,14 @@ const DocsSource = DataSource.Website.fromWebsite(
     maxDepth: 5,
   }
 )
+```
+
+For JS-rendered sites, add `fetch: "integration:browser"` to the options and add the Browser integration to your agent (see [Integrations](/adk/setup/integrations)).
+
+```typescript
+const DocsSource = DataSource.Website.fromWebsite("https://example.com", {
+  fetch: "integration:browser",
+})
 ```
 
 ### Website from llms.txt
@@ -114,7 +122,7 @@ All four website factories accept the same options:
 |--------|------|-------------|
 | `id` | `string` | Optional unique identifier for the source |
 | `filter` | `(ctx) => boolean` | Filter function receiving `{ url, lastmod?, changefreq?, priority? }` |
-| `fetch` | `string \| function` | Fetch strategy: `"node:fetch"` (default), `"integration:browser"`, or a custom function |
+| `fetch` | `string \| function` | Fetch strategy: `"node:fetch"` (default) for static sites, `"integration:browser"` for JS-rendered sites, or a custom function |
 | `maxPages` | `number` | Maximum pages to index (1–50000, default: 50000) |
 | `maxDepth` | `number` | Maximum sitemap depth (1–20, default: 20) |
 


### PR DESCRIPTION
## Summary

- Adds a note and code example to `fromWebsite` explaining that JS-rendered sites require `fetch: "integration:browser"` and the Browser integration
- Updates the `fetch` option description in the website source options table to mention static vs JS-rendered sites