### PR TITLE
fix: add callout for desk in hitl guides

### DIFF
--- a/get-started/manage-your-agent/human-handoff.mdx
+++ b/get-started/manage-your-agent/human-handoff.mdx
@@ -5,6 +5,12 @@ tag: Plus
 
 If you want to allow a live agent to join your agent's conversations, you can configure this in the **<Icon icon="message-square-reply"/> Human Handoff** section of your bot's menu.
 
+<Warning>
+  For new workspaces, Human Handoff has moved to [Botpress Desk](https://botpress.com/desk), our new AI helpdesk for modern support teams. Go to **Human Handoff > Open Botpress Desk** to get started setting up your workspace.
+
+  Users on existing workspaces can follow the steps below and continue using the legacy HITL integration.
+</Warning>
+
 ## Setup
 
 To get started using Human Handoff, you need to install and configure the official Human-in-the-Loop (HITL) integration:

--- a/integrations/integration-guides/hitl/introduction.mdx
+++ b/integrations/integration-guides/hitl/introduction.mdx
@@ -15,6 +15,11 @@ import Triggers from '/snippets/integrations/triggers/botpress/hitl.mdx'
 
 <OpenInHub integration={integrationVersions.hitl}/>
 
+<Warning>
+  For new workspaces, HITL has moved to [Botpress Desk](https://botpress.com/desk), our new AI helpdesk for modern support teams. From your dashboard, go to <Icon icon="message-square-reply"/> **Human Handoff > Open Botpress Desk** to get started setting up your workspace.
+
+  Users on existing workspaces can follow the steps below and continue using the legacy HITL integration.
+</Warning>
 
 The Human-in-the-Loop (HITL) integration allows members of your Workspace to:
 


### PR DESCRIPTION
Adds a callout instructing new workspaces to use Desk instead of HITL/Human Handoff.