### PR TITLE
feat: update docs assistant to a single unified bot

### DIFF
--- a/assistant.js
+++ b/assistant.js
@@ -539,6 +539,14 @@
   }
 
   function initInputBubble() {
+    // The iframe is created in a separate IIFE, so resolve it from the DOM here
+    // (this closure can't see initBotPanel's getActiveIframe). Without this the
+    // bottom "Ask a question" bar threw a ReferenceError and silently did nothing.
+    function getActiveIframe() {
+      const container = document.getElementById('docs-bot')
+      return container ? container.querySelector('iframe') : null
+    }
+
     const inputBubble = document.createElement('div')
     inputBubble.id = 'ask-ai-input-bubble'
     inputBubble.classList.add('ask-ai-input-bubble')
@@ -792,6 +800,13 @@
 
   function initAskAIOverride() {
     const overriddenButtons = new WeakSet()
+
+    // Resolve the iframe from the DOM (defined in a separate IIFE) so this
+    // closure can message it.
+    function getActiveIframe() {
+      const container = document.getElementById('docs-bot')
+      return container ? container.querySelector('iframe') : null
+    }
 
     function findAndOverrideButton() {
       const button = document.getElementById('page-context-menu-button')

--- a/assistant.js
+++ b/assistant.js
@@ -58,19 +58,8 @@
     botContainer.id = 'docs-bot'
     botContainer.classList.add('bot-iframe-container')
 
-    // The default docs bot covers everything under botpress.com/docs.
-    // The ADK section gets its own bot (agent-0) with knowledge scoped to
-    // ADK pages + the ADK skill references. The iframe URL is swapped on
-    // route changes — see checkPathChange below.
-    const DEFAULT_BOT_URL = 'https://botpress.github.io/docs-bot/'
-    const ADK_BOT_URL = 'https://botpress.github.io/docs-bot/adk-bot-frontend/'
-
-    function isAdkRoute() {
-      // Match /docs/adk/<subpage> on the live site (pathname includes /docs/ prefix).
-      // The bare /adk and /adk/ teaser routes keep using the default docs bot.
-      return /\/adk\/.+/.test(window.location.pathname)
-    }
-
+    // A single docs assistant (marg) covers everything under botpress.com/docs.
+    const MARG_BOT_URL = 'https://botpress.github.io/docs-bot/marg-frontend/'
 
     const iframe = document.createElement('iframe')
     iframe.title = 'Botpress'
@@ -80,78 +69,49 @@
     iframe.style.top = '0'
     iframe.style.left = '0'
     iframe.allow = 'clipboard-write'
-    iframe.src = DEFAULT_BOT_URL
-
-    const adkIframe = document.createElement('iframe')
-    adkIframe.title = 'Botpress ADK'
-    adkIframe.style.width = '100%'
-    adkIframe.style.height = '100%'
-    adkIframe.style.position = 'absolute'
-    adkIframe.style.top = '0'
-    adkIframe.style.left = '0'
-    adkIframe.allow = 'clipboard-write'
-    adkIframe.src = ADK_BOT_URL
+    iframe.src = MARG_BOT_URL
 
     // "ready" means the React app inside the iframe has mounted and rendered its
     // first frame. We detect this via the `requestTheme` postMessage the frontend
-    // sends from a useEffect on mount — that fires after the first paint, not just
-    // after the HTML document loads. The `load` event fires too early (HTML loaded
-    // but React not yet mounted), so using it directly causes a blank-white flash.
-    let defaultReady = false
-    let adkReady = false
+    // sends from a useEffect on mount — the `load` event fires too early (HTML
+    // loaded but React not yet mounted), so using it directly causes a flash.
+    let ready = false
 
-    function markReady(isAdk) {
-      if (isAdk) adkReady = true
-      else defaultReady = true
+    function markReady() {
+      ready = true
       showActiveIframe()
     }
 
-    // Fallback: if the iframe never sends requestTheme (e.g. default docs bot
-    // doesn't have the hook), mark ready 600ms after the HTML load event so the
-    // panel isn't stuck hidden forever.
+    // Fallback: if the iframe never sends requestTheme, mark ready 600ms after
+    // the HTML load event so the panel isn't stuck hidden forever.
     iframe.addEventListener('load', () => {
-      setTimeout(() => { if (!defaultReady) markReady(false) }, 600)
-    })
-    adkIframe.addEventListener('load', () => {
-      setTimeout(() => { if (!adkReady) markReady(true) }, 600)
+      setTimeout(() => { if (!ready) markReady() }, 600)
     })
 
     function showActiveIframe() {
-      const adk = isAdkRoute()
-      const target = adk ? adkIframe : iframe
-      const other = adk ? iframe : adkIframe
-      const ready = adk ? adkReady : defaultReady
-
       if (ready) {
-        // Bring the active bot to the front (z-index swap, no repaint = no flash).
-        target.style.zIndex = '2'
-        target.style.pointerEvents = 'auto'
-        other.style.zIndex = '0'
-        other.style.pointerEvents = 'none'
+        iframe.style.zIndex = '2'
+        iframe.style.pointerEvents = 'auto'
       }
-      // If target isn't ready yet, leave both layers as-is — 'other' keeps its
-      // current z-index so the panel stays populated. markReady() fires again
-      // once the target's React app has mounted.
     }
 
+    // Kept as a function so downstream message senders need no changes.
     function getActiveIframe() {
-      return isAdkRoute() ? adkIframe : iframe
+      return iframe
     }
 
-    // Default starts above ADK so non-ADK pages show the correct bot before
-    // either React app sends its first readiness signal (requestTheme).
     iframe.style.zIndex = '1'
     iframe.style.pointerEvents = 'none'
-    adkIframe.style.zIndex = '0'
-    adkIframe.style.pointerEvents = 'none'
 
     botContainer.style.position = 'relative'
     botContainer.appendChild(iframe)
-    botContainer.appendChild(adkIframe)
     showActiveIframe()
 
     panel.appendChild(mobileDismiss)
     resizeHandle.appendChild(toggleCloseButton)
+    // The iframe header now provides the collapse control, so hide this edge
+    // toggle to avoid two "hide" buttons. The drag-to-resize handle remains.
+    toggleCloseButton.style.display = 'none'
     panel.appendChild(botContainer)
     panel.appendChild(resizeHandle)
 
@@ -248,6 +208,27 @@
       updateOverlay()
     }
 
+    // Maximize/restore the panel width (driven by the iframe's expand button).
+    // Remembers the prior inline width so "restore" returns to the CSS default
+    // or a drag-resized width. Persisted so it survives in-docs navigation.
+    let widePrevWidth = ''
+    let isWide = false
+    function setWide(wide) {
+      if (wide === isWide) return
+      if (wide) {
+        widePrevWidth = panel.style.width
+        const target = Math.round(Math.min(window.innerWidth * 0.6, 820))
+        panel.style.width = target + 'px'
+      } else {
+        panel.style.width = widePrevWidth
+      }
+      isWide = wide
+      try { sessionStorage.setItem('bot-panel-wide', wide ? '1' : '0') } catch (e) {}
+    }
+    function toggleWidth() {
+      setWide(!isWide)
+    }
+
     let isResizing = false
     let startX = 0
     let startWidth = 0
@@ -258,13 +239,12 @@
       if (e.target.closest('#bot-toggle-close')) {
         return
       }
+      // Drag-to-resize is intentionally disabled: the panel uses fixed widths
+      // (default + the expand button). We still track press/move here only so a
+      // plain click on the edge can toggle the panel, while a drag is ignored.
       isResizing = true
       hasMoved = false
       startX = e.clientX
-      startWidth = parseInt(window.getComputedStyle(panel).width, 10)
-      panel.classList.add('resizing')
-      document.body.style.cursor = 'col-resize'
-      document.body.style.userSelect = 'none'
       e.preventDefault()
       e.stopPropagation()
     })
@@ -276,13 +256,7 @@
       if (moveDistance > clickThreshold) {
         hasMoved = true
       }
-
-      if (hasMoved) {
-        const diff = startX - e.clientX
-        const maxWidth = window.innerWidth * 1
-        const newWidth = Math.max(368, Math.min(maxWidth, startWidth + diff))
-        panel.style.width = newWidth + 'px'
-      }
+      // No width mutation — resizing the panel by dragging is disabled.
 
       e.preventDefault()
       e.stopPropagation()
@@ -291,14 +265,6 @@
     document.addEventListener('mouseup', (e) => {
       if (isResizing) {
         isResizing = false
-        panel.classList.remove('resizing')
-        document.body.style.cursor = ''
-        document.body.style.userSelect = ''
-
-        if (!hasMoved) {
-          togglePanel()
-        }
-
         hasMoved = false
         e.preventDefault()
         e.stopPropagation()
@@ -413,6 +379,10 @@
         closePanel()
       }
 
+      if (event.data.type === 'toggleWidth') {
+        toggleWidth()
+      }
+
       if (event.data.type === 'requestCurrentPage') {
         sendPanelOpenedMessage()
       }
@@ -452,11 +422,7 @@
         const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light'
         // The iframe's React app just mounted — mark it as visually ready so we
         // can show it without a blank-white flash.
-        if (event.source === adkIframe.contentWindow) {
-          if (!adkReady) markReady(true)
-        } else if (event.source === iframe.contentWindow) {
-          if (!defaultReady) markReady(false)
-        }
+        if (event.source === iframe.contentWindow && !ready) markReady()
         // Respond with the current theme to whichever iframe asked.
         if (event.source && typeof event.source.postMessage === 'function') {
           try { event.source.postMessage({ type: 'themeChanged', theme }, '*') } catch (_e) {}
@@ -464,13 +430,10 @@
       }
     })
 
-    // Watch for docs theme toggles and forward to both iframes so they stay in
-    // sync regardless of which one is currently visible.
+    // Watch for docs theme toggles and forward to the iframe so it stays in sync.
     const themeObserver = new MutationObserver(() => {
       const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light'
-      ;[iframe, adkIframe].forEach(f => {
-        if (f && f.contentWindow) f.contentWindow.postMessage({ type: 'themeChanged', theme }, '*')
-      })
+      if (iframe.contentWindow) iframe.contentWindow.postMessage({ type: 'themeChanged', theme }, '*')
     })
     themeObserver.observe(document.documentElement, {
       attributes: true,
@@ -541,23 +504,19 @@
       if (window.location.pathname !== lastPath) {
         lastPath = window.location.pathname
 
-        showActiveIframe()
-
-        const isExpanded = panel.classList.contains('bot-panel-expanded')
-        if (isExpanded) {
-          const activeIframe = isAdkRoute() ? adkIframe : iframe
-          if (activeIframe && activeIframe.contentWindow) {
-            activeIframe.contentWindow.postMessage(
-              {
-                type: 'pageChanged',
-                data: {
-                  path: window.location.pathname,
-                  title: document.title.replace(' - Botpress', ''),
-                },
+        // Always tell the bot the page changed so it can refresh its page
+        // context, even when the panel is collapsed (it routes on the page URL).
+        if (iframe.contentWindow) {
+          iframe.contentWindow.postMessage(
+            {
+              type: 'pageChanged',
+              data: {
+                path: window.location.pathname,
+                title: document.title.replace(' - Botpress', ''),
               },
-              '*'
-            )
-          }
+            },
+            '*'
+          )
         }
       }
     }

--- a/assistant.js
+++ b/assistant.js
@@ -29,18 +29,6 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-panel-right-open-icon lucide-panel-right-open"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M15 3v18"/><path d="m10 15-3-3 3-3"/></svg>
     `
 
-    const toggleCloseButton = document.createElement('button')
-    toggleCloseButton.id = 'bot-toggle-close'
-    toggleCloseButton.classList.add('bot-toggle-close')
-    toggleCloseButton.setAttribute('aria-label', 'Close bot')
-    toggleCloseButton.innerHTML = `
-      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-panel-right-close-icon lucide-panel-right-close"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M15 3v18"/><path d="m8 9 3 3-3 3"/></svg>
-    `
-
-    const resizeHandle = document.createElement('div')
-    resizeHandle.classList.add('bot-resize-handle')
-    resizeHandle.setAttribute('aria-label', 'Resize panel')
-
     const mobileDismiss = document.createElement('div')
     mobileDismiss.classList.add('bot-mobile-dismiss')
     mobileDismiss.setAttribute('aria-label', 'Swipe down to close')
@@ -108,12 +96,7 @@
     showActiveIframe()
 
     panel.appendChild(mobileDismiss)
-    resizeHandle.appendChild(toggleCloseButton)
-    // The iframe header now provides the collapse control, so hide this edge
-    // toggle to avoid two "hide" buttons. The drag-to-resize handle remains.
-    toggleCloseButton.style.display = 'none'
     panel.appendChild(botContainer)
-    panel.appendChild(resizeHandle)
 
     document.body.appendChild(overlay)
     document.body.appendChild(panel)
@@ -229,48 +212,6 @@
       setWide(!isWide)
     }
 
-    let isResizing = false
-    let startX = 0
-    let startWidth = 0
-    let hasMoved = false
-    const clickThreshold = 5
-
-    resizeHandle.addEventListener('mousedown', (e) => {
-      if (e.target.closest('#bot-toggle-close')) {
-        return
-      }
-      // Drag-to-resize is intentionally disabled: the panel uses fixed widths
-      // (default + the expand button). We still track press/move here only so a
-      // plain click on the edge can toggle the panel, while a drag is ignored.
-      isResizing = true
-      hasMoved = false
-      startX = e.clientX
-      e.preventDefault()
-      e.stopPropagation()
-    })
-
-    document.addEventListener('mousemove', (e) => {
-      if (!isResizing) return
-
-      const moveDistance = Math.abs(e.clientX - startX)
-      if (moveDistance > clickThreshold) {
-        hasMoved = true
-      }
-      // No width mutation — resizing the panel by dragging is disabled.
-
-      e.preventDefault()
-      e.stopPropagation()
-    })
-
-    document.addEventListener('mouseup', (e) => {
-      if (isResizing) {
-        isResizing = false
-        hasMoved = false
-        e.preventDefault()
-        e.stopPropagation()
-      }
-    })
-
     let touchStartY = 0
     let touchCurrentY = 0
     let touchStartTime = 0
@@ -329,10 +270,6 @@
     panel.addEventListener('touchcancel', handleTouchEnd, { passive: false })
 
     toggleButton.addEventListener('click', togglePanel)
-    toggleCloseButton.addEventListener('click', (e) => {
-      e.stopPropagation()
-      closePanel()
-    })
     mobileDismiss.addEventListener('click', closePanel)
     overlay.addEventListener('click', (e) => {
       if (isMobile() && panel.classList.contains('bot-panel-expanded')) {

--- a/styles.css
+++ b/styles.css
@@ -206,8 +206,8 @@ img {
 }
 
 .bot-resize-handle:hover {
-  cursor: col-resize;
-  pointer-events: auto;
+  cursor: default;
+  pointer-events: none;
 }
 
 .bot-panel-collapsed #bot-toggle-close {
@@ -240,7 +240,7 @@ img {
   display: flex;
   flex-direction: row;
   transform: translateX(100%);
-  resize: horizontal;
+  resize: none;
   overflow: visible;
   transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -260,10 +260,10 @@ img {
   bottom: 0;
   width: 40px;
   height: 100%;
-  cursor: col-resize;
+  cursor: default;
   background-color: transparent;
   z-index: 30;
-  pointer-events: auto;
+  pointer-events: none;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/styles.css
+++ b/styles.css
@@ -182,52 +182,6 @@ img {
   height: 16px;
 }
 
-#bot-toggle-close {
-  width: 35px;
-  height: 35px;
-  flex-shrink: 0;
-  color: light-dark(#1a1a1a, #fcfcfc);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 32;
-  pointer-events: none;
-  background-color: light-dark(#fcfcfc, #1a1a1a);
-  border: 1px solid light-dark(rgb(226, 222, 230), rgb(255 255 255/0.07));
-  border-radius: 0.75em;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  opacity: 1;
-  transition: opacity 0.2s ease-in-out;
-}
-
-.bot-resize-handle:hover {
-  cursor: default;
-  pointer-events: none;
-}
-
-.bot-panel-collapsed #bot-toggle-close {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.bot-panel-expanded .bot-resize-handle:hover #bot-toggle-close {
-  pointer-events: auto;
-}
-
-#bot-toggle-close:hover {
-  background-color: light-dark(#f0f0f0, #2a2a2a);
-}
-
-#bot-toggle-close svg {
-  width: 16px;
-  height: 16px;
-}
-
 .bot-panel {
   position: fixed;
   top: 3.55rem;
@@ -253,22 +207,6 @@ img {
   transform: translateX(100%);
 }
 
-.bot-resize-handle {
-  position: absolute;
-  left: -20px;
-  top: 0;
-  bottom: 0;
-  width: 40px;
-  height: 100%;
-  cursor: default;
-  background-color: transparent;
-  z-index: 30;
-  pointer-events: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .bot-iframe-container {
   flex: 1;
   height: 100%;
@@ -277,14 +215,6 @@ img {
   pointer-events: auto;
   min-width: 0;
   border-left: 1px solid light-dark(rgb(226, 222, 230), rgb(255 255 255/0.07));
-}
-
-.bot-panel.resizing {
-  transition: none;
-}
-
-.bot-panel.resizing .bot-iframe-container {
-  pointer-events: none;
 }
 
 .bot-iframe {
@@ -325,15 +255,6 @@ img {
 @media (max-width: 1024px) {
   /* Hide desktop elements on mobile */
   #bot-toggle {
-    display: none !important;
-  }
-
-  .bot-resize-handle {
-    display: none !important;
-    pointer-events: none !important;
-  }
-
-  #bot-toggle-close {
     display: none !important;
   }
 


### PR DESCRIPTION
Updates the docs assistant on botpress.com to a single **unified bot**, replacing the previous two-bot setup. The bot is **marg** (a bot in the AI@Botpress workspace).

- `assistant.js`: embeds the marg frontend iframe (served from GitHub Pages), forwards page context / theme / bottom-bar input via postMessage, and adds the expand/restore width toggle.
- `styles.css`: panel drag-to-resize disabled — fixed widths via the header controls only.

Depends on the marg frontend being published at `botpress.github.io/docs-bot/marg-frontend/` (botpress/docs-bot#4), so merge that first.