### PR TITLE
remove manual configuration description

### DIFF
--- a/integrations/integration-guides/hubspot.mdx
+++ b/integrations/integration-guides/hubspot.mdx
@@ -20,110 +20,17 @@ The official HubSpot integration allows your bot to interact with your HubSpot a
 
 ## Setup
 
-<Tabs>
-  <Tab title="Automatic configuration">
-    <Info>
-      You will need:
+<Info>
+  You will need:
 
-      - A [published bot](/get-started/quick-start)
-      - A [HubSpot account](https://hubspot.com)
-    </Info>
+  - A [published bot](/get-started/quick-start)
+  - A [HubSpot account](https://hubspot.com)
+</Info>
 
-    1. In Botpress Studio, select **Explore Hub** in the upper-right corner.
-    2. Search for the **HubSpot** integration, then select **Install Integration**.
-    3. In the **Configuration** menu, select **Authorize HubSpot**.
-    4. Follow the instructions to connect Botpress to your HubSpot account.
-  </Tab>
-  <Tab title="Manual configuration">
-    For advanced use cases, you can use your own HubSpot app with our integration.
-
-    <Info>
-      You will need:
-
-      - A [published bot](/get-started/quick-start)
-      - A [HubSpot account](https://hubspot.com)
-    </Info>
-
-    ### Step 1: Install the HubSpot integration in Botpress
-
-    <Steps>
-      <Step>In Botpress Studio, select **Explore Hub** in the upper-right corner.</Step>
-      <Step>Search for the **HubSpot** integration, then select **Install Integration**.</Step>
-      <Step>In the **Configuration** menu, select the drop-down menu, then select **Manual configuration, use your own HubSpot app**.</Step>
-      <Step>Copy the webhook URL—you'll need it when configuring your HubSpot app.</Step>
-      <Step>Leave the configuration fields empty for now—you'll come back to them after you've setup your HubSpot app.</Step>
-    </Steps>
-
-    ### Step 2: Create a HubSpot app
-
-    Next, you'll need to create a HubSpot app for your bot:
-
-    <Steps>
-      <Step>Open a new tab and [log into your HubSpot account](https://app.hubspot.com/login).</Step>
-      <Step>In the upper-right corner, select your organization name, then select **Profile & Preferences**.</Step>
-      <Step>Under **Account Management**, select **Integrations**, then **Legacy Apps**.</Step>
-      <Step>Select **Create legacy app** in the upper-right corner. Then, select **Private**.</Step>
-    </Steps>
-
-    ### Step 3: Add scopes to your HubSpot app
-
-    Now, add the required scopes for the HubSpot app to work:
-
-    <Steps>
-      <Step>In the **Scopes** section, select **+ Add new scope**.</Step>
-      <Step>
-        Add the following scopes:
-        - `oauth`
-        - `tickets`
-        - `crm.objects.contacts.read`
-        - `crm.objects.contacts.write`
-        - `crm.objects.owners.read`
-        - `crm.objects.companies.read`
-        - `crm.objects.companies.write`
-        - `crm.objects.leads.read`
-        - `crm.objects.leads.write`
-        - `crm.objects.deals.read`
-        - `crm.objects.deals.write`
-      </Step>
-      <Step>When you're done, select **Update**.</Step>
-    </Steps>
-
-    ### Step 4: Subscribe to Webhook events (optional)
-
-    Optionally, you can subscribe to Webhook events—these are necessary if you want to use the integration's [Triggers](/studio/concepts/triggers):
-
-    <Steps>
-      <Step>Navigate to the **Webhooks** tab, then paste the webhook URL you copied earlier into the **Target URL** field.</Step>
-      <Step>Set **Event throttling** to `1`, then select **Create subscription**.</Step>
-      <Step>Enable **Use expanded object support**.</Step>
-      <Step>
-        From the **Which object types** drop-down, select:
-        - Company
-        - Contact
-        - Ticket
-        - Lead
-      </Step>
-      <Step>
-        From the **Listen for which events** drop-down, select:
-        - Created
-        - Deleted
-      </Step>
-      <Step>Select **Subscribe**.</Step>
-      <Step>Select **Create app** in the upper-right corner. Then, select **Continue creating**.</Step>
-    </Steps>
-
-    ### Step 5: Configure the integration in Botpress
-
-    Now you can use your app's credentials to fill in the configuration fields from [Step 1](#install-the-hubspot-integration-in-botpress):
-
-    <Steps>
-      <Step>From your HubSpot app's menu, navigate to the **Auth** tab.</Step>
-      <Step>Copy the **Access token** and **Client secret**.</Step>
-      <Step>Paste them into the integration's **Access Token** and **Client Secret** fields.</Step>
-      <Step>Scroll down and select **Save Configuration**. This automatically activates the integration.</Step>
-    </Steps>
-  </Tab>
-</Tabs>
+1. In Botpress Studio, select **Explore Hub** in the upper-right corner.
+2. Search for the **HubSpot** integration, then select **Install Integration**.
+3. In the **Configuration** menu, select **Authorize HubSpot**.
+4. Follow the instructions to connect Botpress to your HubSpot account.
 
 <Check>
   Your HubSpot integration is ready—you can use the integration's [Cards](/studio/concepts/cards/introduction) and [Triggers](/studio/concepts/triggers) to interact with your HubSpot account.

--- a/snippets/integrations/cards/botpress/hubspot.mdx
+++ b/snippets/integrations/cards/botpress/hubspot.mdx
@@ -745,6 +745,13 @@ Here's a reference for all [Cards](/studio/concepts/cards/introduction) availabl
   </ResponseField>
     </Expandable>
   </ResponseField>
+  <ResponseField
+    name="url"
+    type="string"
+    required
+  >
+    <span>{"The URL to the contact's page in the HubSpot UI"}</span>
+  </ResponseField>
     </Expandable>
   </ResponseField>
 
@@ -820,6 +827,39 @@ Here's a reference for all [Cards](/studio/concepts/cards/introduction) availabl
     </Expandable>
   </ResponseField>
 
+### Get File URL
+
+<span>{"Get a URL to access a file stored in Hubspot Files"}</span>
+
+  <ResponseField
+    name="input"
+    type="object"
+  >
+    <Expandable>
+  <ResponseField
+    name="fileName"
+    type="string"
+    required
+  >
+    <span>{"The path to the Hubspot file"}</span>
+  </ResponseField>
+    </Expandable>
+  </ResponseField>
+
+  <ResponseField
+    name="output"
+    type="object"
+  >
+    <Expandable>
+  <ResponseField
+    name="url"
+    type="string"
+  >
+    <span>{"The URL of the file, or undefined if not available"}</span>
+  </ResponseField>
+    </Expandable>
+  </ResponseField>
+
 ### Get Lead
 
 <span>{"Get a lead from HubSpot"}</span>
@@ -886,6 +926,178 @@ Here's a reference for all [Cards](/studio/concepts/cards/introduction) availabl
     required
   >
     <span>{"The properties of the lead"}</span>
+  </ResponseField>
+    </Expandable>
+  </ResponseField>
+    </Expandable>
+  </ResponseField>
+
+### Get Owner
+
+<span>{"Get a Hubspot owner (user) by ID. Used to resolve owner references on contacts, deals, etc."}</span>
+
+  <ResponseField
+    name="input"
+    type="object"
+  >
+    <Expandable>
+  <ResponseField
+    name="ownerId"
+    type="string"
+    required
+  >
+    <span>{"The ID of the owner to fetch"}</span>
+  </ResponseField>
+    </Expandable>
+  </ResponseField>
+
+  <ResponseField
+    name="output"
+    type="object"
+  >
+    <Expandable>
+  <ResponseField
+    name="owner"
+    type="object"
+  >
+    <span>{"The owner found, or undefined if not found"}</span>
+
+    <Expandable>
+  <ResponseField
+    name="id"
+    type="string"
+    required
+  >
+    <span>{"The ID of the owner"}</span>
+  </ResponseField>
+  <ResponseField
+    name="email"
+    type="string"
+  >
+    <span>{"The email of the owner"}</span>
+  </ResponseField>
+  <ResponseField
+    name="firstName"
+    type="string"
+  >
+    <span>{"The first name of the owner"}</span>
+  </ResponseField>
+  <ResponseField
+    name="lastName"
+    type="string"
+  >
+    <span>{"The last name of the owner"}</span>
+  </ResponseField>
+  <ResponseField
+    name="userId"
+    type="number"
+  >
+    <span>{"The Hubspot user ID associated with the owner"}</span>
+  </ResponseField>
+  <ResponseField
+    name="type"
+    type="string"
+    required
+  >
+    <span>{"The type of owner (e.g. PERSON, QUEUE)"}</span>
+  </ResponseField>
+  <ResponseField
+    name="archived"
+    type="boolean"
+    required
+  >
+    <span>{"Whether the owner is archived"}</span>
+  </ResponseField>
+  <ResponseField
+    name="createdAt"
+    type="string"
+    required
+  >
+    <span>{"The date and time the owner was created"}</span>
+  </ResponseField>
+  <ResponseField
+    name="updatedAt"
+    type="string"
+    required
+  >
+    <span>{"The date and time the owner was last updated"}</span>
+  </ResponseField>
+    </Expandable>
+  </ResponseField>
+    </Expandable>
+  </ResponseField>
+
+### List Contact Properties
+
+<span>{"List all available Hubspot contact properties with their metadata"}</span>
+
+  <ResponseField
+    name="input"
+    type="object"
+  >
+    This Card has no input fields.
+  </ResponseField>
+
+  <ResponseField
+    name="output"
+    type="object"
+  >
+    <Expandable>
+  <ResponseField
+    name="properties"
+    type="array"
+    required
+  >
+    <span>{"The contact properties defined in this Hubspot account"}</span>
+
+    <Expandable title="array item properties">
+  <ResponseField
+    name="name"
+    type="string"
+    required
+  >
+    <span>{"The internal name of the property"}</span>
+  </ResponseField>
+  <ResponseField
+    name="label"
+    type="string"
+    required
+  >
+    <span>{"The human-readable label of the property"}</span>
+  </ResponseField>
+  <ResponseField
+    name="type"
+    type="string"
+    required
+  >
+    <span>{"The data type of the property (e.g. string, number, date, datetime, enumeration, bool)"}</span>
+  </ResponseField>
+  <ResponseField
+    name="fieldType"
+    type="string"
+    required
+  >
+    <span>{"The form field type of the property (e.g. text, textarea, select, radio, checkbox)"}</span>
+  </ResponseField>
+  <ResponseField
+    name="groupName"
+    type="string"
+    required
+  >
+    <span>{"The internal name of the property group"}</span>
+  </ResponseField>
+  <ResponseField
+    name="description"
+    type="string"
+    required
+  >
+    <span>{"The description of the property"}</span>
+  </ResponseField>
+  <ResponseField
+    name="referencedObjectType"
+    type="string"
+  >
+    <span>{"The type of object referenced by this property (e.g. OWNER), if any"}</span>
   </ResponseField>
     </Expandable>
   </ResponseField>
@@ -1100,6 +1312,12 @@ Here's a reference for all [Cards](/studio/concepts/cards/introduction) availabl
   >
     <span>{"The phone number of the contact to search for"}</span>
   </ResponseField>
+  <ResponseField
+    name="properties"
+    type="array"
+  >
+    <span>{"The list of property names to fetch on the matching contact. Defaults to all properties."}</span>
+  </ResponseField>
     </Expandable>
   </ResponseField>
 
@@ -1158,6 +1376,12 @@ Here's a reference for all [Cards](/studio/concepts/cards/introduction) availabl
     <span>{"The properties of the contact"}</span>
   </ResponseField>
     </Expandable>
+  </ResponseField>
+  <ResponseField
+    name="url"
+    type="string"
+  >
+    <span>{"The URL to the contact's page in the HubSpot UI, or undefined if no contact was found"}</span>
   </ResponseField>
     </Expandable>
   </ResponseField>

--- a/snippets/integrations/versions.mdx
+++ b/snippets/integrations/versions.mdx
@@ -304,8 +304,8 @@ export const integrationVersions = {
     "id": "intver_01JFAQXRQ8TADY78EBPBKSXFPC"
   },
   "hubspot": {
-    "version": "6.0.5",
-    "id": "intver_01KRPJKZ1ER9XBZQC5QTXBRGND"
+    "version": "6.0.9",
+    "id": "intver_01KTV8S0ZX48N54R7AVG24CHJZ"
   },
   "hunter": {
     "version": "1.0.2",


### PR DESCRIPTION
we had to remove the description of manual configuration from the hubspot integration guide, in order to proceed with the verification of the hubspot oauth app. 

full context:

https://botpresshq.slack.com/archives/C09E4GFSANL/p1781186720846749